### PR TITLE
💚ci: PR 작성 시 checkout 하는 브랜치를 PR 작성 브랜치로 설정할 수 있도록 분기점 추가

### DIFF
--- a/.github/workflows/integration_workflow.yml
+++ b/.github/workflows/integration_workflow.yml
@@ -28,7 +28,16 @@ jobs:
           --health-retries=3
 
     steps:
-      - name: Checkout repository with submodules
+      - name: Checkout for PR
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          submodules: recursive
+          token: ${{ secrets.PRIVATE_REPO_TOKEN }}
+
+      - name: Checkout for Push Main
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           submodules: recursive


### PR DESCRIPTION
## PR 설명
- [💚ci: PR 작성 시 checkout 하는 브랜치를 PR 작성 브랜치로 설정할 수 있도록 분기점 추가](https://github.com/picklab/picklab-be/commit/e24112c08edcdd5e3572308571b8ef754c850113)
  - 작업을 위한 브랜치에서 서브 모듈에 환경변수가 추가 혹은 수정되어 최신 커밋을 바라볼 수 있도록 업데이트 하더라도 현재의 CI workflow에서는 main 브랜치의 서브모듈 커밋만 참조하게 되어, 최신화 된 환경변수를 적용하지 못하는 문제가 발생했습니다.
  - 이를 위해 PR 작성 시에는 PR에 해당 하는 브랜치를, push 시에는 main 브랜치를 참조하도록 했습니다.
  - 강제 push의 경우 main 브랜치에서만 발생한다고 가정하였습니다.

## 작업 내용

- CI workflow 작업 시 checkout하는 브랜치를 가져올 때 PR인지 push인지 확인하는 분기점 추가

## 리뷰 포인트
