### PR TITLE
👷ci:checkout 한 서브모듈의 env 파일을 적용하도록 변경

### DIFF
--- a/.github/workflows/integration_workflow.yml
+++ b/.github/workflows/integration_workflow.yml
@@ -53,6 +53,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run test
-        env:
-          SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew test
+        shell: bash
+        run: |
+          set -o allexport
+          source ${{ secrets.PRIVATE_ENV_FILE }}
+          set +o allexport
+          export SPRING_PROFILES_ACTIVE=test
+          ./gradlew test


### PR DESCRIPTION
## PR 설명
- [👷ci:checkout 한 서브모듈의 env 파일을 적용하도록 변경](https://github.com/picklab/picklab-be/commit/fbcb76342d29e6e3ec258e66065287806160f63f)
  - 현재 서브모듈을 checkout 할 뿐, 서브모듈 내부의 환경변수를 적용하지 않아 테스트를 통과하지 못하는 문제를 발견했습니다.
  - 서브모듈 checkout 이후, 환경변수를 source 명령어를 통해 github actions 내부 환경변수로 주입하였습니다.
  - test 프로필을 적용하기 위해 별도로 SPRING_PROFILES_ACTVIE를 덮어씌웠습니다.

## 작업 내용
- [ ] CI 시 서브모듈의 환경변수를 적용하도록 변경

## 리뷰 포인트