### PR TITLE
[feat] Archive 생성 로직 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepository.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepository.kt
@@ -1,0 +1,9 @@
+package picklab.backend.activity.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import picklab.backend.activity.domain.entity.Activity
+
+@Repository
+interface ActivityRepository : JpaRepository<Activity, Long> {
+}

--- a/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
@@ -1,0 +1,17 @@
+package picklab.backend.activity.domain.service
+
+import org.springframework.stereotype.Service
+import picklab.backend.activity.domain.entity.Activity
+import picklab.backend.activity.domain.repository.ActivityRepository
+import picklab.backend.common.model.BusinessException
+import picklab.backend.common.model.ErrorCode
+
+@Service
+class ActivityService(
+    private val activityRepository: ActivityRepository,
+) {
+
+    fun mustFindById(activityId: Long): Activity = activityRepository
+        .findById(activityId)
+        .orElseThrow { throw BusinessException(ErrorCode.NOT_FOUND_ACTIVITY) }
+}

--- a/src/main/kotlin/picklab/backend/archive/application/ArchiveUseCase.kt
+++ b/src/main/kotlin/picklab/backend/archive/application/ArchiveUseCase.kt
@@ -1,0 +1,40 @@
+package picklab.backend.archive.application
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.activity.domain.service.ActivityService
+import picklab.backend.archive.domain.entity.ArchiveReferenceUrl
+import picklab.backend.archive.domain.entity.ArchiveUploadFileUrl
+import picklab.backend.archive.domain.service.ArchiveReferenceUrlService
+import picklab.backend.archive.domain.service.ArchiveService
+import picklab.backend.archive.domain.service.ArchiveUploadFileUrlService
+import picklab.backend.archive.entrypoint.request.ArchiveCreateRequest
+import picklab.backend.common.model.MemberPrincipal
+import picklab.backend.member.domain.MemberService
+
+@Component
+class ArchiveUseCase(
+    private val memberService: MemberService,
+    private val archiveService: ArchiveService,
+    private val activityService: ActivityService,
+    private val archiveReferenceUrlService: ArchiveReferenceUrlService,
+    private val archiveUploadFileUrlService: ArchiveUploadFileUrlService,
+) {
+    @Transactional
+    fun createArchive(
+        request: ArchiveCreateRequest,
+        memberPrincipal: MemberPrincipal,
+    ) {
+        val member = memberService.findActiveMember(memberPrincipal.memberId)
+        val activity = activityService.mustFindById(request.activityId)
+
+        val entity = request.toCreateEntity(member, activity)
+        val archive = archiveService.save(entity)
+
+        val referenceUrls = request.referenceUrls.map { url -> ArchiveReferenceUrl(archive, url) }
+        val uploadedFileUrls = request.fileUrls.map { url -> ArchiveUploadFileUrl(archive, url) }
+
+        archiveReferenceUrlService.saveAll(referenceUrls)
+        archiveUploadFileUrlService.saveAll(uploadedFileUrls)
+    }
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/enums/ProgressStatus.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/enums/ProgressStatus.kt
@@ -3,6 +3,7 @@ package picklab.backend.archive.domain.enums
 enum class ProgressStatus(
     val label: String,
 ) {
+    IN_PROGRESSING("진행중"),
     COMPLETED("수료 완료"),
     DROPPED("중도 포기"),
 }

--- a/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveReferenceUrlRepository.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveReferenceUrlRepository.kt
@@ -1,0 +1,9 @@
+package picklab.backend.archive.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import picklab.backend.archive.domain.entity.ArchiveReferenceUrl
+
+@Repository
+interface ArchiveReferenceUrlRepository : JpaRepository<ArchiveReferenceUrl, Long> {
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveRepository.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveRepository.kt
@@ -1,0 +1,10 @@
+package picklab.backend.archive.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import picklab.backend.archive.domain.entity.Archive
+
+@Repository
+interface ArchiveRepository : JpaRepository<Archive, Long> {
+
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveUploadFileUrlRepository.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/repository/ArchiveUploadFileUrlRepository.kt
@@ -1,0 +1,9 @@
+package picklab.backend.archive.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import picklab.backend.archive.domain.entity.ArchiveUploadFileUrl
+
+@Repository
+interface ArchiveUploadFileUrlRepository : JpaRepository<ArchiveUploadFileUrl, Long> {
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveReferenceUrlService.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveReferenceUrlService.kt
@@ -1,0 +1,15 @@
+package picklab.backend.archive.domain.service
+
+import org.springframework.stereotype.Service
+import picklab.backend.archive.domain.entity.ArchiveReferenceUrl
+import picklab.backend.archive.domain.repository.ArchiveReferenceUrlRepository
+
+
+@Service
+class ArchiveReferenceUrlService(
+    private val archiveReferenceUrlRepository: ArchiveReferenceUrlRepository
+) {
+    fun saveAll(referenceUrls: Collection<ArchiveReferenceUrl>) {
+        archiveReferenceUrlRepository.saveAll(referenceUrls)
+    }
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveService.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveService.kt
@@ -1,0 +1,18 @@
+package picklab.backend.archive.domain.service
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import picklab.backend.archive.domain.entity.Archive
+import picklab.backend.archive.domain.repository.ArchiveReferenceUrlRepository
+import picklab.backend.archive.domain.repository.ArchiveRepository
+
+@Service
+class ArchiveService(
+    private val archiveRepository: ArchiveRepository,
+) {
+
+    @Transactional
+    fun save(entity: Archive): Archive {
+        return archiveRepository.save(entity)
+    }
+}

--- a/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveUploadFileUrlService.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/service/ArchiveUploadFileUrlService.kt
@@ -1,0 +1,14 @@
+package picklab.backend.archive.domain.service
+
+import org.springframework.stereotype.Service
+import picklab.backend.archive.domain.entity.ArchiveUploadFileUrl
+import picklab.backend.archive.domain.repository.ArchiveUploadFileUrlRepository
+
+@Service
+class ArchiveUploadFileUrlService(
+    private val archiveUploadFileUrlRepository: ArchiveUploadFileUrlRepository,
+) {
+    fun saveAll(uploadedFileUrls: Collection<ArchiveUploadFileUrl>) {
+        archiveUploadFileUrlRepository.saveAll(uploadedFileUrls)
+    }
+}

--- a/src/main/kotlin/picklab/backend/archive/entrypoint/ArchiveController.kt
+++ b/src/main/kotlin/picklab/backend/archive/entrypoint/ArchiveController.kt
@@ -1,0 +1,23 @@
+package picklab.backend.archive.entrypoint
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import picklab.backend.archive.application.ArchiveUseCase
+import picklab.backend.archive.entrypoint.request.ArchiveCreateRequest
+import picklab.backend.common.model.MemberPrincipal
+
+@RestController
+class ArchiveController (
+    private val archiveUseCase: ArchiveUseCase,
+){
+
+    @PostMapping("/v1/archive")
+    fun create(
+        @AuthenticationPrincipal member: MemberPrincipal,
+        @RequestBody request: ArchiveCreateRequest
+    ) {
+        archiveUseCase.createArchive(request, member)
+    }
+}

--- a/src/main/kotlin/picklab/backend/archive/entrypoint/request/ArchiveCreateRequest.kt
+++ b/src/main/kotlin/picklab/backend/archive/entrypoint/request/ArchiveCreateRequest.kt
@@ -1,0 +1,38 @@
+package picklab.backend.archive.entrypoint.request
+
+import picklab.backend.activity.domain.entity.Activity
+import picklab.backend.activity.domain.enums.ActivityType
+import picklab.backend.archive.domain.entity.Archive
+import picklab.backend.archive.domain.enums.DetailRoleType
+import picklab.backend.archive.domain.enums.ProgressStatus
+import picklab.backend.archive.domain.enums.RoleType
+import picklab.backend.archive.domain.enums.WriteStatus
+import picklab.backend.member.domain.entity.Member
+import java.time.LocalDate
+
+class ArchiveCreateRequest(
+    val activityId: Long,
+    val detailRole: DetailRoleType,
+    val activityRecord: String,
+    val activityType: ActivityType,
+    val fileUrls: List<String>,
+    val referenceUrls: List<String>,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val role: RoleType,
+    val customRole: String?,
+) {
+    fun toCreateEntity(member: Member, activity: Activity): Archive = Archive(
+        member = member,
+        activity = activity,
+        detailRole = detailRole,
+        activityType = activityType,
+        activityRecord = activityRecord,
+        userStartDate = startDate,
+        userEndDate = endDate,
+        role = role,
+        activityProgressStatus = ProgressStatus.IN_PROGRESSING,
+        writeStatus = WriteStatus.IN_PROGRESS,
+        customRole = customRole,
+    )
+}

--- a/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
@@ -31,4 +31,9 @@ enum class ErrorCode(
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 유효하지 않습니다."),
     EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     JOB_CATEGORY_LIMIT(HttpStatus.BAD_REQUEST, "관심 직군은 최대 5개까지 선택할 수 있습니다."),
+
+    /**
+     * 활동 도메인 관련
+     */
+    NOT_FOUND_ACTIVITY(HttpStatus.BAD_REQUEST, "활동 정보를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/picklab/backend/member/domain/MemberService.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/MemberService.kt
@@ -269,7 +269,7 @@ class MemberService(
         notificationPreferenceRepository.save(notificationPreference)
     }
 
-    private fun findActiveMember(memberId: Long): Member =
+    fun findActiveMember(memberId: Long): Member =
         memberRepository
             .findByIdAndDeletedAtIsNull(memberId)
             .orElseThrow { BusinessException(ErrorCode.INVALID_MEMBER) }


### PR DESCRIPTION
## PR 설명
기존에 있던 entity들을 활용하여 Archive 생성 로직을 구현하였습니다.
Archive를 생성하면 연관해서 activity, member와 연결 관계를 가지게 되고 추가적으로 이미지와 url 정보를 저장하게 됩니다.

## 작업 내용

1. [x] archive, archive reference url, upload file url repository, service 구현체 구현
2. [x] 생성 로직에 대한 usecase 로직 작성

## 리뷰 포인트
제가 누락한 포인트가 없는지 같이 확인 부탁드립니다.
추가적으로 entity를 생성할 때 0을 넣고 있는데 0으로 넣으면 id가 계속 0으로 생성될 것 같은데 새로운 entity라는 것을 jpa에서 어떻게 판단하고 있는지 궁금합니다. 아니면 해당 부분은 고려가 안되어 있는걸 수도 있겠네요

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->