### PR TITLE
♻️refactor: QueryDSL 적용 및 기존 쿼리 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,12 +4,14 @@ plugins {
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
+    id("com.google.devtools.ksp") version "1.9.25-1.0.20"
 }
 
 group = "picklab"
 version = "0.0.1-SNAPSHOT"
 val swaggerVersion = "2.8.8"
 val jjwtVersion = "0.12.6"
+val queryDSLVersion = "7.0"
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
@@ -50,6 +52,11 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+
+    // QueryDSL
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDSLVersion")
+    ksp("io.github.openfeign.querydsl:querydsl-ksp-codegen:$queryDSLVersion")
+    annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDSLVersion:jakarta")
 }
 
 kotlin {

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
@@ -27,6 +27,9 @@ import java.time.LocalDate
 )
 @Table(name = "activity")
 abstract class Activity(
+    @Column(name = "activity_type", insertable = false, updatable = false)
+    @Comment("활동 유형 (대외활동, 공모전/해커톤, 강연/세미나, 교육)")
+    val activityType: String? = null,
     @Column(name = "title", nullable = false, length = 50)
     @Comment("활동명")
     var title: String,

--- a/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepositoryImpl.kt
@@ -1,164 +1,175 @@
 package picklab.backend.activity.domain.repository
 
-import jakarta.persistence.EntityManager
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import picklab.backend.activity.application.model.ActivityItem
 import picklab.backend.activity.application.model.ActivitySearchCommand
+import picklab.backend.activity.domain.entity.QActivity
+import picklab.backend.activity.domain.entity.QActivityGroup
+import picklab.backend.activity.domain.entity.QActivityJobCategory
+import picklab.backend.activity.domain.enums.ActivityFieldType
 import picklab.backend.activity.domain.enums.ActivitySortType
-import java.sql.Date
+import picklab.backend.activity.domain.enums.DomainType
+import picklab.backend.activity.domain.enums.EducationCostType
+import picklab.backend.activity.domain.enums.EducationFormatType
+import picklab.backend.activity.domain.enums.LocationType
+import picklab.backend.job.domain.entity.QJobCategory
+import java.time.LocalDate
+import kotlin.collections.map
 
 @Repository
 class ActivityRepositoryImpl(
-    private val entityManager: EntityManager,
+    private val jpaQueryFactory: JPAQueryFactory,
 ) : ActivityRepositoryCustom {
     override fun getActivities(
         queryData: ActivitySearchCommand,
         pageable: PageRequest,
     ): Page<ActivityItem> {
-        val (condition, params) = createCondition(queryData)
+        val a = QActivity.activity
+        val ag = QActivityGroup.activityGroup
+        val ajc = QActivityJobCategory.activityJobCategory
+        val jc = QJobCategory.jobCategory
+
+        val condition = createGetActivitiesCondition(queryData, a, jc)
 
         val orderBy =
             when (queryData.sort) {
-                ActivitySortType.LATEST -> "ORDER BY a.created_at DESC"
-                ActivitySortType.DEADLINE_ASC -> "ORDER BY a.recruitment_end_date ASC, a.created_at DESC"
-                ActivitySortType.DEADLINE_DESC -> "ORDER BY DATEDIFF(a.recruitment_end_date, CURRENT_DATE) DESC, a.created_at DESC"
+                ActivitySortType.LATEST -> listOf(a.createdAt.desc())
+                ActivitySortType.DEADLINE_ASC -> listOf(a.recruitmentEndDate.asc(), a.createdAt.desc())
+                ActivitySortType.DEADLINE_DESC ->
+                    listOf(
+                        Expressions
+                            .numberTemplate(
+                                Long::class.java,
+                                "DATEDIFF({0}, {1})",
+                                a.recruitmentEndDate,
+                                LocalDate.now(),
+                            ).desc(),
+                        a.createdAt.desc(),
+                    )
             }
 
-        val itemQuery =
-            """
-            SELECT a.id, a.title, a.organizer, a.start_date, a.activity_type,
-            GROUP_CONCAT(jc.job_detail) AS job_tags,
-            a.activity_thumbnail_url
-            FROM activity a
-            LEFT JOIN activity_group ag ON a.group_id = ag.id
-            LEFT JOIN activity_job_category ajc ON a.id = ajc.activity_id
-            LEFT JOIN job_category jc ON ajc.job_category_id = jc.id
-            $condition
-            GROUP BY a.id, a.title, a.organizer, a.start_date, a.activity_type, a.activity_thumbnail_url, a.created_at
-            $orderBy
-            LIMIT :offset, :size
-            """.trimIndent()
-
-        val countQuery =
-            """
-            SELECT COUNT(DISTINCT a.id)
-            FROM activity a
-            LEFT JOIN activity_group ag ON a.group_id = ag.id
-            LEFT JOIN activity_job_category ajc ON a.id = ajc.activity_id
-            LEFT JOIN job_category jc ON ajc.job_category_id = jc.id
-            $condition
-            """.trimIndent()
-
-        val nativeQuery =
-            entityManager
-                .createNativeQuery(itemQuery)
-                .setParameter("category", queryData.category.name)
-                .setParameter("offset", pageable.offset)
-                .setParameter("size", pageable.pageSize)
-
-        val countNativeQuery =
-            entityManager
-                .createNativeQuery(countQuery)
-                .setParameter("category", queryData.category.name)
-
-        params.forEach { (key, value) ->
-            nativeQuery.setParameter(key, value)
-            countNativeQuery.setParameter(key, value)
-        }
-
-        val result = nativeQuery.resultList as List<Array<Any?>>
-        val total = (countNativeQuery.singleResult as Number).toLong()
+        val result =
+            jpaQueryFactory
+                .select(
+                    a.id,
+                    a.title,
+                    a.organizer,
+                    a.startDate,
+                    a.activityType,
+                    jc.jobDetail,
+                    a.activityThumbnailUrl,
+                ).from(a)
+                .leftJoin(ajc)
+                .on(ajc.activity.id.eq(a.id))
+                .leftJoin(jc)
+                .on(ajc.jobCategory.id.eq(jc.id))
+                .where(condition)
+                .orderBy(*orderBy.toTypedArray())
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
 
         val items =
-            result.map { row ->
-                ActivityItem(
-                    id = (row[0] as Number).toLong(),
-                    title = row[1] as String,
-                    organization = row[2] as String,
-                    startDate = (row[3] as Date).toLocalDate(),
-                    category = row[4] as String,
-                    jobTags = (row[5] as? String)?.split(",") ?: emptyList(),
-                    thumbnailUrl = row[6] as? String,
-                )
-            }
+            result
+                .groupBy { it.get(a.id) }
+                .map { (id, rows) ->
+                    val first = rows.first()
+                    ActivityItem(
+                        id = id!!,
+                        title = first.get(a.title)!!,
+                        organization = first.get(a.organizer)?.toString() ?: "",
+                        startDate = first.get(a.startDate)!!,
+                        category = first.get(a.activityType) ?: "",
+                        jobTags = rows.mapNotNull { it.get(jc.jobDetail)?.toString() }.distinct(),
+                        thumbnailUrl = first.get(a.activityThumbnailUrl),
+                    )
+                }
 
-        return PageImpl(items, pageable, total)
+        val count =
+            jpaQueryFactory
+                .select(a.id.countDistinct())
+                .from(a)
+                .leftJoin(a.activityGroup, ag)
+                .leftJoin(ajc)
+                .on(ajc.activity.id.eq(a.id))
+                .leftJoin(jc)
+                .on(ajc.jobCategory.id.eq(jc.id))
+                .where(condition)
+                .fetchOne() ?: 0L
+
+        return PageImpl(items, pageable, count)
     }
 
-    private fun createCondition(queryData: ActivitySearchCommand): Pair<String, Map<String, Any>> {
-        var condition =
-            """
-            WHERE a.activity_type = :category
-            AND a.deleted_at IS NULL
-            AND a.recruitment_end_date >= CURRENT_DATE
-            """.trimIndent()
-        val params = mutableMapOf<String, Any>()
+    fun createGetActivitiesCondition(
+        queryData: ActivitySearchCommand,
+        a: QActivity,
+        jc: QJobCategory,
+    ): BooleanBuilder {
+        val condition = BooleanBuilder()
+
+        condition.and(a.activityType.eq(queryData.category.name))
+        condition.and(a.deletedAt.isNull)
+        condition.and(a.recruitmentEndDate.goe(LocalDate.now()))
 
         if (!queryData.jobTag.isNullOrEmpty()) {
-            condition += " AND jc.job_detail IN (:jobTags)"
-            params["jobTags"] = queryData.jobTag.map { it.name }
+            condition.and(jc.jobDetail.`in`(queryData.jobTag))
         }
 
         if (!queryData.organizer.isNullOrEmpty()) {
-            condition += " AND a.organizer IN (:organizers)"
-            params["organizers"] = queryData.organizer.map { it.name }
+            condition.and(a.organizer.`in`(queryData.organizer))
         }
 
         if (!queryData.target.isNullOrEmpty()) {
-            condition += " AND a.target_audience IN (:targets)"
-            params["targets"] = queryData.target.map { it.name }
+            condition.and(a.targetAudience.`in`(queryData.target))
         }
 
         if (!queryData.field.isNullOrEmpty()) {
-            condition += " AND a.activity_field IN (:fields)"
-            params["fields"] = queryData.field.map { it.name }
+            condition.and(
+                Expressions.enumPath(ActivityFieldType::class.javaObjectType, "activityField").`in`(queryData.field),
+            )
         }
 
         if (!queryData.location.isNullOrEmpty()) {
-            condition += " AND a.location IN (:locations)"
-            params["locations"] = queryData.location.map { it.name }
+            condition.and(Expressions.enumPath(LocationType::class.javaObjectType, "location").`in`(queryData.location))
         }
 
         if (queryData.format != null) {
-            condition += " AND a.education_format IN (:format)"
-            params["format"] = queryData.format.map { it.name }
+            condition.and(Expressions.enumPath(EducationFormatType::class.javaObjectType, "format").`in`(queryData.format))
         }
 
         if (!queryData.costType.isNullOrEmpty()) {
-            condition += " AND a.education_cost_type IN (:costTypes)"
-            params["costTypes"] = queryData.costType.map { it.name }
+            condition.and(
+                Expressions.enumPath(EducationCostType::class.javaObjectType, "costType").`in`(queryData.costType),
+            )
         }
 
         if (queryData.award != null) {
             if (queryData.award.size == 1) {
-                condition += " AND a.cost < :maxAward"
-                params["maxAward"] = queryData.award[0]
+                condition.and(Expressions.numberPath(Long::class.javaObjectType, "cost").lt(queryData.award[0]))
             } else {
-                condition += " AND a.cost >= :minAward AND a.cost < :maxAward"
-                params["minAward"] = queryData.award[0]
-                params["maxAward"] = queryData.award[1]
+                condition.and(Expressions.numberPath(Long::class.javaObjectType, "cost").goe(queryData.award[0]))
+                condition.and(Expressions.numberPath(Long::class.javaObjectType, "cost").lt(queryData.award[1]))
             }
         }
 
         if (queryData.duration != null) {
             if (queryData.duration.size == 1) {
-                condition += " AND a.duration < :maxDuration"
-                params["maxDuration"] = queryData.duration[0] * 30
+                condition.and(a.duration.lt(queryData.duration[0] * 30))
             } else {
-                condition += " AND a.duration BETWEEN :minDuration AND :maxDuration"
-                params["minDuration"] = queryData.duration[0] * 30
-                params["maxDuration"] = queryData.duration[1] * 30
+                condition.and(a.duration.between(queryData.duration[0] * 30, queryData.duration[1] * 30))
             }
         }
 
         if (!queryData.domain.isNullOrEmpty()) {
-            condition += " AND a.domain IN (:domains)"
-            params["domains"] = queryData.domain.map { it.name }
+            condition.and(Expressions.enumPath(DomainType::class.javaObjectType, "domain").`in`(queryData.domain))
         }
 
-        return condition to params
+        return condition
     }
 }

--- a/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/repository/ActivityRepositoryImpl.kt
@@ -2,7 +2,6 @@ package picklab.backend.activity.domain.repository
 
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.group.GroupBy
-import com.querydsl.core.group.GroupBy.list
 import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions

--- a/src/main/kotlin/picklab/backend/common/config/AuditConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/AuditConfig.kt
@@ -1,18 +1,8 @@
 package picklab.backend.common.config
 
-import com.querydsl.jpa.impl.JPAQueryFactory
-import jakarta.persistence.EntityManager
-import jakarta.persistence.PersistenceContext
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @Configuration
 @EnableJpaAuditing
-class AuditConfig {
-    @PersistenceContext
-    private val entityManager: EntityManager? = null
-
-    @Bean
-    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
-}
+class AuditConfig

--- a/src/main/kotlin/picklab/backend/common/config/AuditConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/AuditConfig.kt
@@ -1,8 +1,18 @@
 package picklab.backend.common.config
 
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @Configuration
 @EnableJpaAuditing
-class AuditConfig
+class AuditConfig {
+    @PersistenceContext
+    private val entityManager: EntityManager? = null
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/picklab/backend/common/config/JpaConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/JpaConfig.kt
@@ -1,0 +1,16 @@
+package picklab.backend.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JpaConfig {
+    @PersistenceContext
+    private val entityManager: EntityManager? = null
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}


### PR DESCRIPTION
## PR 설명

- [🔧config: QueryDSL 의존성 추가 및 config 설정](https://github.com/picklab/picklab-be/commit/c25eddaf996f845fcf9cbcf95814eb0372e1050b)
  - 기존 `QueryDSL`의 경우 5.1.0 버전을 마지막으로 지원이 중단된 상태이기 때문에 적용하는 것에 대해 고민이 있었습니다.
  - 하지만, `OpenFeign` 에서 `QueryDSL`을 유지보수하는 것을 확인하고 최신 버전을 적용하였습니다.
    - ([OpenFeign/querydsl Github](https://github.com/OpenFeign/querydsl?tab=readme-ov-file))
  - 이에 따라, 최신 버전 의존성 추가 및 `JPAQueryFactory`를 사용하기 위한 설정을 추가하였습니다
-  [✨feat: Activity 엔티티에서 activity_type 조회할 수 있도록 읽기 전용 컬럼추가](https://github.com/picklab/picklab-be/commit/1613650dd376898565efe5f111bf31c502def406)
   - QueryDSL의 Q클래스는 엔티티 기반으로 동작하기 때문에 별도로 컬럼으로 지정되지 않은 `activity_type`을 조회하지 못하는 문제가 존재하였습니다.
   - 이를 해결하기 위해 삽입,수정이 불가능한 읽기 전용 엔티티 데이터를 추가하였습니다.
- [♻️refactor: 활동 조회 기능 쿼리 NativeQuery -> QueryDSL로 마이그레이션](https://github.com/picklab/picklab-be/commit/fa9cda00cbb7d149dba84233f2d0222286baf5e4)
  - 기존 Native쿼리로 작성된 쿼리를 QueryDSL로 마이그레이션 하였습니다.
  - 추상화된 컬럼의 경우 Q클래스를 추가하지 않고 `.enumPath()`, `.numberPath()` 등을 활용하여 추상 Q클래스만을 이용하도록 작성했습니다.

### 2025/07/02 변경사항
- [♻️refactor: config 파일 분리(JpaConfig 추가)](https://github.com/picklab/picklab-be/pull/23/commits/2bc9c21878bdd15a8e96d86130e0f4d99f11877e)
  - AuditConfig에 JPA 관련 설정이 추가되어 있어 이를 분리했습니다.

- [♻️refactor: inline 함수 도입 및 Projection 적용](https://github.com/picklab/picklab-be/pull/23/commits/a319e9f48afbc4f6c6691fb84242fa50446b45eb)
  - 기존 조건절을 만드는 함수를 별도 메소드로 분리하였을 때, 가독성을 해치는 부분이 있어 `BooleanBuilder()`의 메소드 체이닝 방식을 적용하였습니다.
  - if 조건절이 중첩되는 문제를 Inline 함수를 통해 가독성을 향상 및 중복 사용을 방지했습니다.
  - QueryDSL Projection을 적용하여 DB에서 데이터를 가져옴과 동시에 DTO에 매핑이 가능하도록 변경했습니다.
  - Q클래스를 단순변수로 작성하지 않고, Q클래스 자체를 사용하여 명시적으로 테이블을 표현하도록 변경했습니다.

## 작업 내용

- [x] QueryDSL 의존성 추가(v7.0)
- [x] QueryDSL 사용을 위한 설정 추가
- [x] 기존 활동 조회 쿼리 QueryDSL 방식으로 마이그레이션

## 리뷰 포인트

- condition을 설정하는 부분이 너무 길어진다고 생각해서 별도의 메소드로 나누었는데, 이 부분도 오히려 왔다갔다해야 해서 가독성을 해치는 부분이 될까요?

- `activity_type`을 별도의 컬럼을 생성하지 않고 가져올 수 있는 방법을 찾지 못하였는데, 혹시 가능한 방법이 별도로 있을지 궁금합니다.