### PR TITLE
refactor : ArchUnit을 이용해서 UseCase에서 다른 UseCase를 호출하는지 확인하도록 로직 수정

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
@@ -7,11 +7,12 @@ import picklab.backend.activity.application.model.ActivitySearchCommand
 import picklab.backend.activity.domain.service.ActivityService
 import picklab.backend.activity.entrypoint.response.GetActivityListResponse
 import picklab.backend.bookmark.application.BookmarkUseCase
+import picklab.backend.bookmark.domain.BookmarkService
 
 @Component
 class ActivityUseCase(
     private val activityService: ActivityService,
-    private val bookmarkUseCase: BookmarkUseCase,
+    private val bookmarkService: BookmarkService,
 ) {
     fun getActivities(
         queryParams: ActivitySearchCommand,
@@ -32,7 +33,7 @@ class ActivityUseCase(
         val activityIds = activityItems.map { it.id }
 
         val bookmarkedActivityIds =
-            bookmarkUseCase.getMyBookmarkedActivityIds(
+            bookmarkService.getActivityIdsBookmarkedByMember(
                 memberId = memberId,
                 activityIds = activityIds,
             )

--- a/src/main/kotlin/picklab/backend/member/entrypoint/request/AdditionalInfoRequest.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/request/AdditionalInfoRequest.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Pattern
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
 import picklab.backend.member.domain.enums.EmploymentType
 
 data class AdditionalInfoRequest(
@@ -38,4 +40,8 @@ data class AdditionalInfoRequest(
     @field:JsonProperty("interested_job_categories")
     @field:Schema(description = "관심 직무 카테고리")
     val interestedJobCategories: List<JobCategoryDto>,
-)
+){
+    fun toJobGroupDetailMap(): List<Pair<JobGroup, JobDetail>> = this.interestedJobCategories.map {
+        JobGroup.valueOf(it.group) to JobDetail.valueOf(it.detail)
+    }
+}

--- a/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
+++ b/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
@@ -11,34 +11,6 @@ class UseCaseArchitectureTest {
     private val importedClasses: JavaClasses = ClassFileImporter()
         .importPackages("picklab.backend")
 
-    @Test
-    fun useCasesShouldOnlyDependOnServiceLayer() {
-        val rule = classes()
-            .that().haveSimpleNameEndingWith("UseCase")
-            .should().onlyDependOnClassesThat()
-            .resideInAnyPackage(
-                "picklab.backend..service..",
-                "picklab.backend..infrastructure..", 
-                "picklab.backend..model..",
-                "picklab.backend..enums..",
-                "picklab.backend..entity..",
-                "java..",
-                "kotlin..",
-                "org.springframework..",
-                "org.jetbrains.annotations..",
-                "jakarta.."
-            )
-            .orShould().dependOnClassesThat()
-            .haveSimpleNameEndingWith("Service")
-            .orShould().dependOnClassesThat()
-            .haveSimpleNameEndingWith("Provider")
-            .orShould().dependOnClassesThat()
-            .haveSimpleNameEndingWith("Mapper")
-            .orShould().dependOnClassesThat()
-            .areInterfaces()
-
-        rule.check(importedClasses)
-    }
 
     @Test
     fun useCasesShouldNotDependOnOtherUseCases() {

--- a/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
+++ b/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
@@ -1,0 +1,75 @@
+package picklab.backend.convention
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.junit.jupiter.api.Test
+
+class UseCaseArchitectureTest {
+
+    private val importedClasses: JavaClasses = ClassFileImporter().importPackages("picklab.backend")
+
+    @Test
+    fun useCasesShouldOnlyDependOnServiceLayer() {
+        val rule = classes()
+            .that().haveSimpleNameEndingWith("UseCase")
+            .should().onlyDependOnClassesThat()
+            .resideInAnyPackage(
+                "picklab.backend..service..",
+                "picklab.backend..infrastructure..", 
+                "picklab.backend..model..",
+                "picklab.backend..enums..",
+                "picklab.backend..entity..",
+                "java..",
+                "kotlin..",
+                "org.springframework..",
+                "org.jetbrains.annotations..",
+                "jakarta.."
+            )
+            .orShould().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Service")
+            .orShould().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Provider")
+            .orShould().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Mapper")
+            .orShould().dependOnClassesThat()
+            .areInterfaces()
+
+        rule.check(importedClasses)
+    }
+
+    @Test
+    fun useCasesShouldNotDependOnOtherUseCases() {
+        val rule = noClasses()
+            .that().haveSimpleNameEndingWith("UseCase")
+            .should().dependOnClassesThat()
+            .haveSimpleNameEndingWith("UseCase")
+            .because("UseCase should not depend on other UseCase classes")
+            .allowEmptyShould(true)
+
+        rule.check(importedClasses)
+    }
+
+    @Test
+    fun useCasesShouldNotDependOnRepositories() {
+        val rule = noClasses()
+            .that().haveSimpleNameEndingWith("UseCase")
+            .should().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Repository")
+            .because("UseCase should not depend on Repository directly, use Service instead")
+
+        rule.check(importedClasses)
+    }
+
+    @Test
+    fun useCasesShouldNotDependOnControllers() {
+        val rule = noClasses()
+            .that().haveSimpleNameEndingWith("UseCase")
+            .should().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Controller")
+            .because("UseCase should not depend on Controller")
+
+        rule.check(importedClasses)
+    }
+} 

--- a/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
+++ b/src/test/kotlin/picklab/backend/convention/UseCaseArchitectureTest.kt
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test
 
 class UseCaseArchitectureTest {
 
-    private val importedClasses: JavaClasses = ClassFileImporter().importPackages("picklab.backend")
+    private val importedClasses: JavaClasses = ClassFileImporter()
+        .importPackages("picklab.backend")
 
     @Test
     fun useCasesShouldOnlyDependOnServiceLayer() {


### PR DESCRIPTION
## PR 설명
[refactor : ArchUnit을 이용해서 UseCase에서 다른 UseCase를 호출하는지 확인하도록 로직 추가](https://github.com/picklab/picklab-be/commit/7c7f2e646cac262bd493eef00ab63d7188f92f18)

[refactor: usecase 에서 다른 usecase를 호출하는 케이스 수정](https://github.com/picklab/picklab-be/pull/27/commits/0836aa0f94f378906cc03feafac194b62386f0b3)

## 작업 내용
- [x] ArchUnit을 이용해서 UseCase에서 다른 UseCase를 호출하는지 확인하도록 로직 추가
- [x] 기존에 UseCase에서 UseCase를 호출하고 있는 부분 정리

## 리뷰 포인트
추가적으로 확인해보면 좋을 것 같은 정책에 대해서 같이 이야기 해보면 좋을 것 같아요

## 참고 자료
