### PR TITLE
feat : SSE를 이용하여 알림 구독/전송/조회 기능 구현

### DIFF
--- a/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
@@ -28,6 +28,7 @@ enum class ErrorCode(
      * 회원 도메인 관련
      */
     INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "회원을 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 유효하지 않습니다."),
     EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     JOB_CATEGORY_LIMIT(HttpStatus.BAD_REQUEST, "관심 직군은 최대 5개까지 선택할 수 있습니다."),
@@ -41,4 +42,9 @@ enum class ErrorCode(
      * 아카이브 도메인 관련
      */
     NOT_FOUND_ARCHIVE(HttpStatus.NOT_FOUND, "아카이브 정보를 찾을 수 없습니다."),
+
+    /**
+     * 알림 도메인 관련
+     */
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -29,4 +29,11 @@ enum class SuccessCode(
     // Archive 도메인 관련
     CREATE_ARCHIVE_SUCCESS(HttpStatus.OK, "아카이브 생성에 성공했습니다."),
     UPDATE_ARCHIVE_SUCCESS(HttpStatus.OK, "아카이브 수정에 성공했습니다."),
+
+    // Notification 도메인 관련
+    SEND_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 전송에 성공했습니다."),
+    GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공했습니다."),
+    MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
+    MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
+    GET_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "읽지 않은 알림 개수 조회에 성공했습니다.")
 }

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -33,6 +33,7 @@ enum class SuccessCode(
     // Notification 도메인 관련
     SEND_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 전송에 성공했습니다."),
     GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공했습니다."),
+    GET_RECENT_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "최근 알림 목록 조회에 성공했습니다."),
     MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
     MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
     GET_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "읽지 않은 알림 개수 조회에 성공했습니다.")

--- a/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
+++ b/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
@@ -37,6 +37,13 @@ class NotificationUseCase(
     }
 
     /**
+     * 최근 n일 내 알림 조회
+     */
+    fun getRecentNotifications(memberId: Long, days: Int): List<NotificationResponse> {
+        return notificationService.getRecentNotifications(memberId, days)
+    }
+
+    /**
      * 알림 읽음 처리
      */
     fun markAsRead(notificationId: Long, memberId: Long): NotificationResponse {
@@ -55,5 +62,37 @@ class NotificationUseCase(
      */
     fun getUnreadCount(memberId: Long): Long {
         return notificationService.getUnreadCount(memberId)
+    }
+
+    /**
+     * 특정 사용자에게 직접 알림 전송 (내부 사용)
+     */
+    fun sendDirectNotification(
+        receiverId: Long,
+        title: String,
+        type: String,
+        link: String
+    ): NotificationResponse {
+        val request = NotificationCreateRequest(
+            receiverId = receiverId,
+            title = title,
+            type = type,
+            link = link
+        )
+        return sendNotification(request)
+    }
+
+    /**
+     * SSE 연결 상태 확인
+     */
+    fun isUserConnected(memberId: Long): Boolean {
+        return sseEmitterService.isUserConnected(memberId)
+    }
+
+    /**
+     * 현재 연결된 사용자 수 조회
+     */
+    fun getConnectedUserCount(): Int {
+        return sseEmitterService.getConnectedUserCount()
     }
 }

--- a/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
+++ b/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
@@ -1,0 +1,59 @@
+package picklab.backend.notification.application
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import picklab.backend.notification.domain.service.NotificationService
+import picklab.backend.notification.domain.service.SseEmitterService
+import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
+import picklab.backend.notification.entrypoint.response.NotificationResponse
+
+@Component
+class NotificationUseCase(
+    private val notificationService: NotificationService,
+    private val sseEmitterService: SseEmitterService
+) {
+
+    /**
+     * SSE 알림 구독
+     */
+    fun subscribeNotifications(memberId: Long): SseEmitter {
+        return sseEmitterService.createEmitter(memberId)
+    }
+
+    /**
+     * 알림 전송
+     */
+    fun sendNotification(request: NotificationCreateRequest): NotificationResponse {
+        return notificationService.createAndSendNotification(request)
+    }
+
+    /**
+     * 내 알림 목록 조회
+     */
+    fun getMyNotifications(memberId: Long, pageable: Pageable): Page<NotificationResponse> {
+        return notificationService.getNotificationsByMemberId(memberId, pageable)
+    }
+
+    /**
+     * 알림 읽음 처리
+     */
+    fun markAsRead(notificationId: Long, memberId: Long): NotificationResponse {
+        return notificationService.markAsRead(notificationId, memberId)
+    }
+
+    /**
+     * 모든 알림 읽음 처리
+     */
+    fun markAllAsRead(memberId: Long): Int {
+        return notificationService.markAllAsRead(memberId)
+    }
+
+    /**
+     * 읽지 않은 알림 개수 조회
+     */
+    fun getUnreadCount(memberId: Long): Long {
+        return notificationService.getUnreadCount(memberId)
+    }
+}

--- a/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
@@ -1,0 +1,46 @@
+package picklab.backend.notification.domain.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import picklab.backend.notification.domain.entity.Notification
+
+@Repository
+interface NotificationRepository : JpaRepository<Notification, Long> {
+    
+    /**
+     * 특정 사용자의 알림 목록을 조회합니다
+     */
+    fun findByMemberIdOrderByCreatedAtDesc(
+        memberId: Long,
+        pageable: Pageable
+    ): Page<Notification>
+    
+    /**
+     * 특정 사용자의 읽지 않은 알림 개수를 조회합니다
+     */
+    fun countByMemberIdAndIsReadFalse(memberId: Long): Long
+    
+    /**
+     * 특정 사용자의 특정 알림을 조회합니다
+     */
+    fun findByIdAndMemberId(id: Long, memberId: Long): Notification?
+    
+    /**
+     * 특정 사용자의 모든 읽지 않은 알림을 읽음 상태로 변경합니다
+     */
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.member.id = :memberId AND n.isRead = false")
+    fun markAllAsReadByMemberId(@Param("memberId") memberId: Long): Int
+    
+    /**
+     * 특정 사용자의 읽지 않은 알림 목록을 조회합니다
+     */
+    fun findByMemberIdAndIsReadFalseOrderByCreatedAtDesc(
+        memberId: Long
+    ): List<Notification>
+}

--- a/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import picklab.backend.notification.domain.entity.Notification
+import java.time.LocalDateTime
 
 @Repository
 interface NotificationRepository : JpaRepository<Notification, Long> {
@@ -23,7 +24,7 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
     /**
      * 특정 사용자의 읽지 않은 알림 개수를 조회합니다
      */
-    fun countByMemberIdAndIsReadFalse(memberId: Long): Long
+    fun countByMemberIdAndReadIsFalse(memberId: Long): Long
     
     /**
      * 특정 사용자의 특정 알림을 조회합니다
@@ -36,11 +37,12 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.member.id = :memberId AND n.isRead = false")
     fun markAllAsReadByMemberId(@Param("memberId") memberId: Long): Int
-    
+
     /**
-     * 특정 사용자의 읽지 않은 알림 목록을 조회합니다
+     * 특정 사용자의 최근 n일 내 알림을 조회합니다
      */
-    fun findByMemberIdAndIsReadFalseOrderByCreatedAtDesc(
-        memberId: Long
+    fun findByMemberIdAndCreatedAtAfterOrderByCreatedAtDesc(
+        memberId: Long,
+        createdAt: LocalDateTime
     ): List<Notification>
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
@@ -8,11 +8,11 @@ import org.springframework.transaction.annotation.Transactional
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.member.domain.MemberService
-import picklab.backend.member.domain.repository.MemberRepository
 import picklab.backend.notification.domain.entity.Notification
 import picklab.backend.notification.domain.repository.NotificationRepository
 import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
 import picklab.backend.notification.entrypoint.response.NotificationResponse
+import java.time.LocalDateTime
 
 @Service
 @Transactional
@@ -21,9 +21,9 @@ class NotificationService(
     private val memberService: MemberService,
     private val sseEmitterService: SseEmitterService
 ) {
-    
+
     private val logger = LoggerFactory.getLogger(NotificationService::class.java)
-    
+
     /**
      * 알림을 생성하고 실시간으로 전송합니다
      */
@@ -38,16 +38,16 @@ class NotificationService(
             link = request.link,
             member = receiver
         )
-        
+
         // 알림 저장
         val savedNotification = notificationRepository.save(notification)
-        
+
         // 실시간 알림 전송
         sendRealtimeNotification(savedNotification)
-        
+
         return NotificationResponse.from(savedNotification)
     }
-    
+
     /**
      * 실시간 알림을 전송합니다
      */
@@ -61,7 +61,7 @@ class NotificationService(
                     "notification",
                     response
                 )
-                
+
                 if (success) {
                     logger.info("실시간 알림 전송 성공. memberId: ${notification.member.id}, notificationId: ${notification.id}")
                 } else {
@@ -74,7 +74,7 @@ class NotificationService(
             logger.error("실시간 알림 전송 중 오류 발생", e)
         }
     }
-    
+
     /**
      * 특정 사용자의 알림 목록을 조회합니다
      */
@@ -85,23 +85,35 @@ class NotificationService(
         )
         return notifications.map { NotificationResponse.from(it) }
     }
-    
+
+    /**
+     * 특정 사용자의 최근 n일 내 알림을 조회합니다
+     */
+    @Transactional(readOnly = true)
+    fun getRecentNotifications(memberId: Long, days: Int): List<NotificationResponse> {
+        val cutoffDate = LocalDateTime.now().minusDays(days.toLong())
+        val notifications = notificationRepository.findByMemberIdAndCreatedAtAfterOrderByCreatedAtDesc(
+            memberId, cutoffDate
+        )
+        return notifications.map { NotificationResponse.from(it) }
+    }
+
     /**
      * 알림을 읽음 상태로 변경합니다
      */
     fun markAsRead(notificationId: Long, memberId: Long): NotificationResponse {
         val notification = notificationRepository.findByIdAndMemberId(notificationId, memberId)
             ?: throw BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND)
-        
+
         notification.isRead = true
         val savedNotification = notificationRepository.save(notification)
-        
+
         // 읽음 상태 변경을 실시간으로 전송
         sendReadStatusUpdate(savedNotification)
-        
+
         return NotificationResponse.from(savedNotification)
     }
-    
+
     /**
      * 읽음 상태 변경을 실시간으로 전송합니다
      */
@@ -120,19 +132,19 @@ class NotificationService(
             logger.error("읽음 상태 업데이트 실시간 전송 중 오류 발생", e)
         }
     }
-    
+
     /**
      * 특정 사용자의 모든 알림을 읽음 상태로 변경합니다
      */
     fun markAllAsRead(memberId: Long): Int {
         val updatedCount = notificationRepository.markAllAsReadByMemberId(memberId)
-        
+
         // 모든 알림 읽음 처리를 실시간으로 전송
         sendAllReadStatusUpdate(memberId)
-        
+
         return updatedCount
     }
-    
+
     /**
      * 모든 알림 읽음 처리를 실시간으로 전송합니다
      */
@@ -150,12 +162,12 @@ class NotificationService(
             logger.error("모든 알림 읽음 처리 실시간 전송 중 오류 발생", e)
         }
     }
-    
+
     /**
      * 특정 사용자의 읽지 않은 알림 개수를 조회합니다
      */
     @Transactional(readOnly = true)
     fun getUnreadCount(memberId: Long): Long {
-        return notificationRepository.countByMemberIdAndIsReadFalse(memberId)
+        return notificationRepository.countByMemberIdAndReadIsFalse(memberId)
     }
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
@@ -1,0 +1,161 @@
+package picklab.backend.notification.domain.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.common.model.BusinessException
+import picklab.backend.common.model.ErrorCode
+import picklab.backend.member.domain.MemberService
+import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.notification.domain.entity.Notification
+import picklab.backend.notification.domain.repository.NotificationRepository
+import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
+import picklab.backend.notification.entrypoint.response.NotificationResponse
+
+@Service
+@Transactional
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+    private val memberService: MemberService,
+    private val sseEmitterService: SseEmitterService
+) {
+    
+    private val logger = LoggerFactory.getLogger(NotificationService::class.java)
+    
+    /**
+     * 알림을 생성하고 실시간으로 전송합니다
+     */
+    fun createAndSendNotification(request: NotificationCreateRequest): NotificationResponse {
+        // 수신자 조회
+        val receiver = memberService.findActiveMember(request.receiverId)
+
+        // 알림 생성
+        val notification = Notification(
+            title = request.title,
+            type = request.type,
+            link = request.link,
+            member = receiver
+        )
+        
+        // 알림 저장
+        val savedNotification = notificationRepository.save(notification)
+        
+        // 실시간 알림 전송
+        sendRealtimeNotification(savedNotification)
+        
+        return NotificationResponse.from(savedNotification)
+    }
+    
+    /**
+     * 실시간 알림을 전송합니다
+     */
+    private fun sendRealtimeNotification(notification: Notification) {
+        try {
+            val isConnected = sseEmitterService.isUserConnected(notification.member.id!!)
+            if (isConnected) {
+                val response = NotificationResponse.from(notification)
+                val success = sseEmitterService.sendEventToUser(
+                    notification.member.id!!,
+                    "notification",
+                    response
+                )
+                
+                if (success) {
+                    logger.info("실시간 알림 전송 성공. memberId: ${notification.member.id}, notificationId: ${notification.id}")
+                } else {
+                    logger.warn("실시간 알림 전송 실패. memberId: ${notification.member.id}, notificationId: ${notification.id}")
+                }
+            } else {
+                logger.info("사용자가 연결되어 있지 않음. memberId: ${notification.member.id}, notificationId: ${notification.id}")
+            }
+        } catch (e: Exception) {
+            logger.error("실시간 알림 전송 중 오류 발생", e)
+        }
+    }
+    
+    /**
+     * 특정 사용자의 알림 목록을 조회합니다
+     */
+    @Transactional(readOnly = true)
+    fun getNotificationsByMemberId(memberId: Long, pageable: Pageable): Page<NotificationResponse> {
+        val notifications = notificationRepository.findByMemberIdOrderByCreatedAtDesc(
+            memberId, pageable
+        )
+        return notifications.map { NotificationResponse.from(it) }
+    }
+    
+    /**
+     * 알림을 읽음 상태로 변경합니다
+     */
+    fun markAsRead(notificationId: Long, memberId: Long): NotificationResponse {
+        val notification = notificationRepository.findByIdAndMemberId(notificationId, memberId)
+            ?: throw BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND)
+        
+        notification.isRead = true
+        val savedNotification = notificationRepository.save(notification)
+        
+        // 읽음 상태 변경을 실시간으로 전송
+        sendReadStatusUpdate(savedNotification)
+        
+        return NotificationResponse.from(savedNotification)
+    }
+    
+    /**
+     * 읽음 상태 변경을 실시간으로 전송합니다
+     */
+    private fun sendReadStatusUpdate(notification: Notification) {
+        try {
+            val isConnected = sseEmitterService.isUserConnected(notification.member.id!!)
+            if (isConnected) {
+                val response = NotificationResponse.from(notification)
+                sseEmitterService.sendEventToUser(
+                    notification.member.id!!,
+                    "notification_read",
+                    response
+                )
+            }
+        } catch (e: Exception) {
+            logger.error("읽음 상태 업데이트 실시간 전송 중 오류 발생", e)
+        }
+    }
+    
+    /**
+     * 특정 사용자의 모든 알림을 읽음 상태로 변경합니다
+     */
+    fun markAllAsRead(memberId: Long): Int {
+        val updatedCount = notificationRepository.markAllAsReadByMemberId(memberId)
+        
+        // 모든 알림 읽음 처리를 실시간으로 전송
+        sendAllReadStatusUpdate(memberId)
+        
+        return updatedCount
+    }
+    
+    /**
+     * 모든 알림 읽음 처리를 실시간으로 전송합니다
+     */
+    private fun sendAllReadStatusUpdate(memberId: Long) {
+        try {
+            val isConnected = sseEmitterService.isUserConnected(memberId)
+            if (isConnected) {
+                sseEmitterService.sendEventToUser(
+                    memberId,
+                    "all_notifications_read",
+                    mapOf("message" to "모든 알림이 읽음 처리되었습니다.")
+                )
+            }
+        } catch (e: Exception) {
+            logger.error("모든 알림 읽음 처리 실시간 전송 중 오류 발생", e)
+        }
+    }
+    
+    /**
+     * 특정 사용자의 읽지 않은 알림 개수를 조회합니다
+     */
+    @Transactional(readOnly = true)
+    fun getUnreadCount(memberId: Long): Long {
+        return notificationRepository.countByMemberIdAndIsReadFalse(memberId)
+    }
+}

--- a/src/main/kotlin/picklab/backend/notification/domain/service/SseEmitterService.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/service/SseEmitterService.kt
@@ -1,0 +1,101 @@
+package picklab.backend.notification.domain.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class SseEmitterService {
+    
+    private val logger = LoggerFactory.getLogger(SseEmitterService::class.java)
+    
+    // 사용자별 SseEmitter 연결을 관리하는 Map
+    private val emitters = ConcurrentHashMap<Long, SseEmitter>()
+    
+    companion object {
+        private const val DEFAULT_TIMEOUT = 60L * 1000 * 60 // 60분
+    }
+    
+    /**
+     * 사용자의 SSE 연결을 생성하고 관리합니다
+     */
+    fun createEmitter(memberId: Long): SseEmitter {
+        val emitter = SseEmitter(DEFAULT_TIMEOUT)
+        
+        // 기존 연결이 있다면 완료 처리
+        emitters[memberId]?.complete()
+        
+        // 새로운 연결 저장
+        emitters[memberId] = emitter
+        
+        // 연결 완료 시 정리
+        emitter.onCompletion {
+            logger.info("SSE 연결이 완료되었습니다. memberId: $memberId")
+            emitters.remove(memberId)
+        }
+        
+        // 연결 타임아웃 시 정리
+        emitter.onTimeout {
+            logger.info("SSE 연결이 타임아웃되었습니다. memberId: $memberId")
+            emitters.remove(memberId)
+        }
+        
+        // 연결 에러 시 정리
+        emitter.onError {
+            logger.error("SSE 연결에 에러가 발생했습니다. memberId: $memberId", it)
+            emitters.remove(memberId)
+        }
+        
+        // 연결 성공 이벤트 전송
+        try {
+            emitter.send(
+                SseEmitter.event()
+                    .name("connect")
+                    .data("SSE 연결이 성공했습니다.")
+            )
+        } catch (e: Exception) {
+            logger.error("초기 연결 이벤트 전송 실패. memberId: $memberId", e)
+            emitters.remove(memberId)
+            emitter.completeWithError(e)
+        }
+        
+        return emitter
+    }
+    
+    /**
+     * 특정 사용자에게 이벤트를 전송합니다
+     */
+    fun sendEventToUser(memberId: Long, eventName: String, data: Any): Boolean {
+        val emitter = emitters[memberId] ?: return false
+        
+        try {
+            emitter.send(
+                SseEmitter.event()
+                    .name(eventName)
+                    .data(data)
+            )
+            return true
+        } catch (e: Exception) {
+            logger.error("이벤트 전송 실패. memberId: $memberId, eventName: $eventName", e)
+            // 전송 실패 시 연결 제거
+            emitters.remove(memberId)
+            emitter.completeWithError(e)
+            return false
+        }
+    }
+    
+    /**
+     * 현재 연결된 사용자 수를 반환합니다
+     */
+    fun getConnectedUserCount(): Int {
+        return emitters.size
+    }
+    
+    /**
+     * 특정 사용자가 연결되어 있는지 확인합니다
+     */
+    fun isUserConnected(memberId: Long): Boolean {
+        return emitters.containsKey(memberId)
+    }
+} 

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
@@ -49,6 +49,18 @@ interface NotificationApi {
     ): ResponseWrapper<Page<NotificationResponse>>
 
     @Operation(
+        summary = "최근 n일 내 알림 조회",
+        description = "현재 로그인한 사용자의 최근 n일 내 알림을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "최근 알림 조회 성공")
+    @GetMapping("/notifications/recent")
+    fun getRecentNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        @Parameter(description = "조회할 일 수", example = "7")
+        @RequestParam(defaultValue = "7") days: Int
+    ): ResponseWrapper<List<NotificationResponse>>
+
+    @Operation(
         summary = "알림 읽음 처리",
         description = "특정 알림을 읽음 상태로 변경합니다."
     )

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
@@ -1,0 +1,81 @@
+package picklab.backend.notification.entrypoint
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import picklab.backend.common.model.MemberPrincipal
+import picklab.backend.common.model.ResponseWrapper
+import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
+import picklab.backend.notification.entrypoint.response.NotificationResponse
+
+@Tag(name = "알림", description = "알림 관련 API 문서 입니다.")
+interface NotificationApi {
+
+    @Operation(
+        summary = "SSE 알림 구독",
+        description = "실시간 알림을 받기 위한 SSE 연결을 생성합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
+    @GetMapping("/notifications/subscribe")
+    fun subscribeNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): SseEmitter
+
+    @Operation(
+        summary = "알림 전송",
+        description = "특정 사용자에게 알림을 전송합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "알림 전송 성공")
+    @PostMapping("/notifications/send")
+    fun sendNotification(
+        @RequestBody request: NotificationCreateRequest
+    ): ResponseWrapper<NotificationResponse>
+
+    @Operation(
+        summary = "내 알림 목록 조회",
+        description = "현재 로그인한 사용자의 알림 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
+    @GetMapping("/notifications")
+    fun getMyNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        pageable: Pageable
+    ): ResponseWrapper<Page<NotificationResponse>>
+
+    @Operation(
+        summary = "알림 읽음 처리",
+        description = "특정 알림을 읽음 상태로 변경합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공")
+    @PatchMapping("/notifications/{notificationId}/read")
+    fun markAsRead(
+        @Parameter(description = "알림 ID") @PathVariable notificationId: Long,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<NotificationResponse>
+
+    @Operation(
+        summary = "모든 알림 읽음 처리",
+        description = "현재 로그인한 사용자의 모든 알림을 읽음 상태로 변경합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "모든 알림 읽음 처리 성공")
+    @PatchMapping("/notifications/read-all")
+    fun markAllAsRead(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<Unit>
+
+    @Operation(
+        summary = "읽지 않은 알림 개수 조회",
+        description = "현재 로그인한 사용자의 읽지 않은 알림 개수를 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "읽지 않은 알림 개수 조회 성공")
+    @GetMapping("/notifications/unread-count")
+    fun getUnreadCount(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<Long>
+}

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
@@ -38,6 +38,14 @@ class NotificationController(
         return ResponseWrapper.success(SuccessCode.GET_NOTIFICATIONS_SUCCESS, notifications)
     }
 
+    override fun getRecentNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        @RequestParam(defaultValue = "30") days: Int
+    ): ResponseWrapper<List<NotificationResponse>> {
+        val notifications = notificationUseCase.getRecentNotifications(memberPrincipal.memberId, days)
+        return ResponseWrapper.success(SuccessCode.GET_RECENT_NOTIFICATIONS_SUCCESS, notifications)
+    }
+
     override fun markAsRead(
         @PathVariable notificationId: Long,
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
@@ -1,0 +1,62 @@
+package picklab.backend.notification.entrypoint
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import picklab.backend.common.model.MemberPrincipal
+import picklab.backend.common.model.ResponseWrapper
+import picklab.backend.common.model.SuccessCode
+import picklab.backend.notification.application.NotificationUseCase
+import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
+import picklab.backend.notification.entrypoint.response.NotificationResponse
+
+@RestController
+class NotificationController(
+    private val notificationUseCase: NotificationUseCase
+) : NotificationApi {
+
+    override fun subscribeNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): SseEmitter {
+        return notificationUseCase.subscribeNotifications(memberPrincipal.memberId)
+    }
+
+    override fun sendNotification(
+        @RequestBody request: NotificationCreateRequest
+    ): ResponseWrapper<NotificationResponse> {
+        val response = notificationUseCase.sendNotification(request)
+        return ResponseWrapper.success(SuccessCode.SEND_NOTIFICATION_SUCCESS, response)
+    }
+
+    override fun getMyNotifications(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        pageable: Pageable
+    ): ResponseWrapper<Page<NotificationResponse>> {
+        val notifications = notificationUseCase.getMyNotifications(memberPrincipal.memberId, pageable)
+        return ResponseWrapper.success(SuccessCode.GET_NOTIFICATIONS_SUCCESS, notifications)
+    }
+
+    override fun markAsRead(
+        @PathVariable notificationId: Long,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<NotificationResponse> {
+        val response = notificationUseCase.markAsRead(notificationId, memberPrincipal.memberId)
+        return ResponseWrapper.success(SuccessCode.MARK_NOTIFICATION_READ_SUCCESS, response)
+    }
+
+    override fun markAllAsRead(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<Unit> {
+        notificationUseCase.markAllAsRead(memberPrincipal.memberId)
+        return ResponseWrapper.success(SuccessCode.MARK_ALL_NOTIFICATIONS_READ_SUCCESS)
+    }
+
+    override fun getUnreadCount(
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<Long> {
+        val count = notificationUseCase.getUnreadCount(memberPrincipal.memberId)
+        return ResponseWrapper.success(SuccessCode.GET_UNREAD_COUNT_SUCCESS, count)
+    }
+}

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/request/NotificationCreateRequest.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/request/NotificationCreateRequest.kt
@@ -1,0 +1,18 @@
+package picklab.backend.notification.entrypoint.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "알림 생성 요청")
+data class NotificationCreateRequest(
+    @Schema(description = "수신자 회원 ID", example = "1")
+    val receiverId: Long,
+    
+    @Schema(description = "알림 제목", example = "새로운 활동이 등록되었습니다")
+    val title: String,
+    
+    @Schema(description = "알림 타입", example = "ACTIVITY_CREATED")
+    val type: String,
+    
+    @Schema(description = "클릭 시 이동할 링크", example = "/activities/123")
+    val link: String
+) 

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/response/NotificationResponse.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/response/NotificationResponse.kt
@@ -1,0 +1,39 @@
+package picklab.backend.notification.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.notification.domain.entity.Notification
+import java.time.LocalDateTime
+
+@Schema(description = "알림 응답")
+data class NotificationResponse(
+    @Schema(description = "알림 ID", example = "1")
+    val id: Long,
+    
+    @Schema(description = "알림 제목", example = "새로운 활동이 등록되었습니다")
+    val title: String,
+    
+    @Schema(description = "알림 타입", example = "ACTIVITY_CREATED")
+    val type: String,
+    
+    @Schema(description = "클릭 시 이동할 링크", example = "/activities/123")
+    val link: String,
+    
+    @Schema(description = "읽음 여부", example = "false")
+    val isRead: Boolean,
+    
+    @Schema(description = "생성일시", example = "2024-01-01T12:00:00")
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResponse {
+            return NotificationResponse(
+                id = notification.id!!,
+                title = notification.title,
+                type = notification.type,
+                link = notification.link,
+                isRead = notification.isRead,
+                createdAt = notification.createdAt
+            )
+        }
+    }
+} 


### PR DESCRIPTION
## PR 설명
[SSE를 이용하여 알림 구독/전송 기능 구현](https://github.com/picklab/picklab-be/commit/c42e54b9421046fa8cf1e6752944118cdb1ac8b1)
[SSE를 이용하여 알림 조회 기능 구현](https://github.com/picklab/picklab-be/commit/950d7ae93fc1b60ac92cfd362072b7e8ab34e526)

## 작업 내용

- [ ] SSE를 이용하여 알림 구독/전송 기능 구현
- [ ] 최근 30일내 알림 조회 기능 구현

## 리뷰 포인트
- 지금은 SSE로 간단하게 구현했는데 나중에는 FCM을 이용해서 구독과 알림을 관리하는 것이 더 좋을 것 같습니다. 웹에서도 사용가능한 구독/발행 기능이 분명 있을 것 같습니다.
- 추가적으로 아카이브가 생성되고 나면 자동으로 알림이 전송되도록 하고 그리고 주기적으로 알림을 확인하고 기간이 많이 안남아있는 공고에 대해서 알림을 보내는 배치성 작업을 별도로 만들어야할 것 같습니다

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->