### PR TITLE
feat : 30일 지난 알림에 대해서 삭제 처리하는 배치 스케줄러 구현

### DIFF
--- a/src/main/kotlin/picklab/backend/PickLabApplication.kt
+++ b/src/main/kotlin/picklab/backend/PickLabApplication.kt
@@ -2,8 +2,10 @@ package picklab.backend
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class PickLabApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
@@ -28,6 +29,7 @@ import java.time.LocalDate
 )
 @Table(name = "activity")
 @SQLDelete(sql = "UPDATE activity SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 abstract class Activity(
     @Column(name = "activity_type", insertable = false, updatable = false)
     @Comment("활동 유형 (대외활동, 공모전/해커톤, 강연/세미나, 교육)")

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
@@ -26,6 +27,7 @@ import java.time.LocalDate
     discriminatorType = DiscriminatorType.STRING,
 )
 @Table(name = "activity")
+@SQLDelete(sql = "UPDATE activity SET deleted_at = NOW() WHERE id = ?")
 abstract class Activity(
     @Column(name = "activity_type", insertable = false, updatable = false)
     @Comment("활동 유형 (대외활동, 공모전/해커톤, 강연/세미나, 교육)")

--- a/src/main/kotlin/picklab/backend/archive/domain/entity/Archive.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/entity/Archive.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.enums.ActivityType
 import picklab.backend.archive.domain.enums.DetailRoleType
@@ -25,6 +26,7 @@ import java.time.LocalDate
 @Entity
 @Table(name = "archive")
 @SQLDelete(sql = "UPDATE archive SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 class Archive(
     @Column(name = "user_start_date", nullable = false)
     @Comment("활동 시작일")

--- a/src/main/kotlin/picklab/backend/archive/domain/entity/Archive.kt
+++ b/src/main/kotlin/picklab/backend/archive/domain/entity/Archive.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Lob
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.enums.ActivityType
 import picklab.backend.archive.domain.enums.DetailRoleType
@@ -23,6 +24,7 @@ import java.time.LocalDate
 
 @Entity
 @Table(name = "archive")
+@SQLDelete(sql = "UPDATE archive SET deleted_at = NOW() WHERE id = ?")
 class Archive(
     @Column(name = "user_start_date", nullable = false)
     @Comment("활동 시작일")

--- a/src/main/kotlin/picklab/backend/common/model/SoftDeleteEntity.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SoftDeleteEntity.kt
@@ -3,11 +3,9 @@ package picklab.backend.common.model
 import jakarta.persistence.Column
 import jakarta.persistence.MappedSuperclass
 import org.hibernate.annotations.Comment
-import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 
 @MappedSuperclass
-@SQLRestriction("deleted_at IS NULL")
 abstract class SoftDeleteEntity(
     @Column(name = "deleted_at")
     @Comment("삭제 시간")

--- a/src/main/kotlin/picklab/backend/member/domain/entity/Member.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/entity/Member.kt
@@ -3,6 +3,7 @@ package picklab.backend.member.domain.entity
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.enums.EmploymentType
 import picklab.backend.member.domain.enums.SocialType
@@ -12,6 +13,7 @@ import java.time.LocalDateTime
 @Entity
 @Table(name = "member")
 @SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 class Member(
     @Column(name = "name", length = 20, nullable = false)
     @Comment("회원 이름")

--- a/src/main/kotlin/picklab/backend/member/domain/entity/Member.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/entity/Member.kt
@@ -2,6 +2,7 @@ package picklab.backend.member.domain.entity
 
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.enums.EmploymentType
 import picklab.backend.member.domain.enums.SocialType
@@ -10,6 +11,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "member")
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
 class Member(
     @Column(name = "name", length = 20, nullable = false)
     @Comment("회원 이름")

--- a/src/main/kotlin/picklab/backend/member/domain/entity/MemberVerification.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/entity/MemberVerification.kt
@@ -3,12 +3,14 @@ package picklab.backend.member.domain.entity
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.common.model.SoftDeleteEntity
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "member_verification")
 @SQLDelete(sql = "UPDATE member_verification SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 class MemberVerification(
     @Column(name = "email", length = 100, nullable = false)
     @Comment("인증 이메일")

--- a/src/main/kotlin/picklab/backend/member/domain/entity/MemberVerification.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/entity/MemberVerification.kt
@@ -2,11 +2,13 @@ package picklab.backend.member.domain.entity
 
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.common.model.SoftDeleteEntity
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "member_verification")
+@SQLDelete(sql = "UPDATE member_verification SET deleted_at = NOW() WHERE id = ?")
 class MemberVerification(
     @Column(name = "email", length = 100, nullable = false)
     @Comment("인증 이메일")

--- a/src/main/kotlin/picklab/backend/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package picklab.backend.member.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import picklab.backend.member.domain.entity.Member
 import java.util.Optional
 
@@ -10,4 +11,7 @@ interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByIdAndDeletedAtIsNull(memberId: Long): Boolean
 
     fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
+
+    @Query(nativeQuery = true, value = "select * from member where id = :memberId")
+    fun findByIdIgnoreDelete(memberId: Long): Member?
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
@@ -2,11 +2,13 @@ package picklab.backend.notification.domain.entity
 
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
 
 @Entity
 @Table(name = "notification")
+@SQLDelete(sql = "UPDATE notification SET deleted_at = NOW() WHERE id = ?")
 class Notification(
     @Column(name = "title", nullable = false)
     @Comment("알림 제목")

--- a/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
@@ -3,12 +3,14 @@ package picklab.backend.notification.domain.entity
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
 
 @Entity
 @Table(name = "notification")
 @SQLDelete(sql = "UPDATE notification SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 class Notification(
     @Column(name = "title", nullable = false)
     @Comment("알림 제목")

--- a/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
@@ -40,4 +40,12 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         memberId: Long,
         createdAt: LocalDateTime
     ): List<Notification>
+
+    /**
+     * 지정된 날짜 이전에 생성된 알림을 배치 단위로 조회합니다
+     */
+    fun findByCreatedAtBeforeOrderByCreatedAtAsc(
+        cutoffDate: LocalDateTime,
+        pageable: Pageable
+    ): Page<Notification>
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
@@ -48,4 +48,7 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         cutoffDate: LocalDateTime,
         pageable: Pageable
     ): Page<Notification>
+
+    @Query(nativeQuery = true, value = "select * from notification where id = :id")
+    fun findByIdIgnoreDelete(id: Long): Notification?
 }

--- a/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
@@ -34,7 +34,7 @@ class NotificationScheduler(
      * 설정된 보관 기간을 초과한 알림을 자동으로 삭제합니다.
      * 매일 새벽 2시(UTC)에 실행됩니다.
      */
-    @Scheduled(cron = "0 * * * * *", zone = "UTC")
+    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
     @Transactional
     fun cleanupOldNotifications() {
         try {

--- a/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
@@ -32,7 +32,7 @@ class NotificationScheduler(
 
     /**
      * 설정된 보관 기간을 초과한 알림을 자동으로 삭제합니다.
-     * 매일 새벽 2시(UTC)에 실행됩니다.
+     * 매일 새벽 자정(UTC)에 실행됩니다.
      */
     @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
     @Transactional

--- a/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
@@ -1,0 +1,80 @@
+package picklab.backend.notification.infrastructure.scheduler
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.common.util.logger
+import picklab.backend.notification.domain.repository.NotificationRepository
+import java.time.LocalDateTime
+
+/**
+ * 알림 관련 배치 작업을 처리하는 스케줄러
+ */
+@Component
+@ConditionalOnProperty(
+    name = ["app.notification.cleanup.enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+class NotificationScheduler(
+    private val notificationRepository: NotificationRepository,
+    @Value("\${app.notification.cleanup.retention-days:30}")
+    private val retentionDays: Long,
+    @Value("\${app.notification.cleanup.batch-size:100}")
+    private val batchSize: Int
+) {
+
+    private val logger = this.logger()
+
+    /**
+     * 설정된 보관 기간을 초과한 알림을 자동으로 삭제합니다.
+     * 매일 새벽 2시(UTC)에 실행됩니다.
+     */
+    @Scheduled(cron = "0 0 2 * * *", zone = "UTC")
+    @Transactional
+    fun cleanupOldNotifications() {
+        try {
+            logger.info("알림 정리 배치 작업 시작")
+            
+            val cutoffDate = calculateCutoffDate()
+            val deletedCount = processCleanupInBatches(cutoffDate)
+            
+            logger.info("알림 정리 완료: $deletedCount 건 삭제")
+            
+        } catch (e: Exception) {
+            logger.error("알림 정리 배치 작업 중 오류 발생", e)
+            throw e
+        }
+    }
+
+    /**
+     * 배치 단위로 알림을 조회하고 삭제합니다
+     */
+    private fun processCleanupInBatches(cutoffDate: LocalDateTime): Int {
+        var totalDeletedCount = 0
+        
+        while (true) {
+            val pageable: Pageable = PageRequest.of(0, batchSize)
+            val notificationsPage = notificationRepository.findByCreatedAtBeforeOrderByCreatedAtAsc(cutoffDate, pageable)
+            
+            if (notificationsPage.isEmpty) {
+                break
+            }
+            
+            val notifications = notificationsPage.content
+            notificationRepository.deleteAll(notifications)
+            totalDeletedCount += notifications.size
+        }
+        
+        return totalDeletedCount
+    }
+
+    /**
+     * 삭제 기준 날짜를 계산합니다
+     */
+    private fun calculateCutoffDate(): LocalDateTime = LocalDateTime.now().minusDays(retentionDays)
+} 

--- a/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
@@ -67,7 +67,6 @@ class NotificationScheduler(
             
             val notifications = notificationsPage.content
             notificationRepository.deleteAll(notifications)
-            notificationRepository.flush()
             totalDeletedCount += notifications.size
         }
         

--- a/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationScheduler.kt
@@ -34,7 +34,7 @@ class NotificationScheduler(
      * 설정된 보관 기간을 초과한 알림을 자동으로 삭제합니다.
      * 매일 새벽 2시(UTC)에 실행됩니다.
      */
-    @Scheduled(cron = "0 0 2 * * *", zone = "UTC")
+    @Scheduled(cron = "0 * * * * *", zone = "UTC")
     @Transactional
     fun cleanupOldNotifications() {
         try {
@@ -67,6 +67,7 @@ class NotificationScheduler(
             
             val notifications = notificationsPage.content
             notificationRepository.deleteAll(notifications)
+            notificationRepository.flush()
             totalDeletedCount += notifications.size
         }
         

--- a/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
@@ -15,6 +16,7 @@ import picklab.backend.member.domain.entity.Member
 @Entity
 @Table(name = "review")
 @SQLDelete(sql = "UPDATE review SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 class Review(
     @Column(name = "overall_score", nullable = false)
     @Comment("총 평점")

--- a/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
@@ -7,12 +7,14 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
 
 @Entity
 @Table(name = "review")
+@SQLDelete(sql = "UPDATE review SET deleted_at = NOW() WHERE id = ?")
 class Review(
     @Column(name = "overall_score", nullable = false)
     @Comment("총 평점")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,13 @@ spring:
           starttls:
             enable: true
 
+app:
+  notification:
+    cleanup:
+      enabled: true # 알림 정리 배치 작업 활성화 여부
+      retention-days: 30 # 알림 보관 기간 (일)
+      batch-size: 100 # 배치 처리 시 한 번에 처리할 알림 개수
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/db/migration/V1.3__add_notification_indexes.sql
+++ b/src/main/resources/db/migration/V1.3__add_notification_indexes.sql
@@ -1,0 +1,4 @@
+-- notification 테이블 성능 최적화를 위한 인덱스 추가
+
+-- created_at 컬럼 인덱스 (배치 정리 작업 최적화)
+CREATE INDEX notification_idx_01 ON notification (created_at); 

--- a/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
@@ -705,8 +705,8 @@ class MemberServiceTest : IntegrationTest() {
             memberService.withdrawMember(member.id)
 
             // then
-            val withdrawnMember = memberRepository.findById(member.id).orElse(null)
-            assertThat(withdrawnMember).isNotNull
+            val withdrawnMember = memberRepository.findByIdIgnoreDelete(member.id)
+                ?: throw IllegalStateException("Member with id ${member.id} was not found")
             assertThat(withdrawnMember.deletedAt).isNotNull
         }
     }

--- a/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
@@ -706,8 +706,8 @@ class MemberServiceTest : IntegrationTest() {
 
             // then
             val withdrawnMember = memberRepository.findByIdIgnoreDelete(member.id)
-                ?: throw IllegalStateException("Member with id ${member.id} was not found")
-            assertThat(withdrawnMember.deletedAt).isNotNull
+            assertThat(withdrawnMember).isNotNull
+            assertThat(withdrawnMember!!.deletedAt).isNotNull
         }
     }
 

--- a/src/test/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/picklab/backend/notification/infrastructure/scheduler/NotificationSchedulerTest.kt
@@ -1,0 +1,171 @@
+package picklab.backend.notification.infrastructure.scheduler
+
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.helper.CleanUp
+import picklab.backend.job.template.IntegrationTest
+import picklab.backend.member.domain.entity.Member
+import picklab.backend.member.domain.enums.EmploymentType
+import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.notification.domain.entity.Notification
+import picklab.backend.notification.domain.entity.NotificationType
+import picklab.backend.notification.domain.repository.NotificationRepository
+import java.time.LocalDateTime
+
+@TestPropertySource(
+    properties = [
+        "app.notification.cleanup.enabled=true",
+        "app.notification.cleanup.retention-days=30",
+        "app.notification.cleanup.batch-size=10"
+    ]
+)
+class NotificationSchedulerTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var cleanUp: CleanUp
+
+    @Autowired
+    private lateinit var notificationScheduler: NotificationScheduler
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    private lateinit var testMember: Member
+
+    @BeforeEach
+    fun setUp() {
+        cleanUp.all()
+
+        testMember = memberRepository.save(
+            Member(
+                name = "테스트 사용자",
+                email = "test@example.com",
+                company = "테스트 회사",
+                school = "테스트 대학교",
+                department = "컴퓨터공학과",
+                nickname = "테스트닉네임",
+                educationLevel = "대학교 졸업",
+                graduationStatus = "졸업",
+                employmentStatus = "재직중",
+                employmentType = EmploymentType.FULL_TIME,
+                isCompleted = true
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("[성공] 30일 이전에 생성된 알림을 soft delete 처리한다")
+    @Transactional
+    fun `30일 이전에 생성된 알림을 soft delete 처리한다`() {
+        // Given: 30일 이전 알림과 30일 이내 알림 생성
+        val oldNotification = createNotificationWithCreatedAt(
+            title = "30일 이전 알림",
+            createdAt = LocalDateTime.now().minusDays(35)
+        )
+
+        val recentNotification = createNotificationWithCreatedAt(
+            title = "최근 알림",
+            createdAt = LocalDateTime.now().minusDays(10)
+        )
+
+        val todayNotification = createNotificationWithCreatedAt(
+            title = "오늘 알림",
+            createdAt = LocalDateTime.now()
+        )
+
+        // 저장 전 상태 확인
+        assertThat(oldNotification.deletedAt).isNull()
+        assertThat(recentNotification.deletedAt).isNull()
+        assertThat(todayNotification.deletedAt).isNull()
+
+        // When: 스케줄러 실행
+        notificationScheduler.cleanupOldNotifications()
+        entityManager.flush()
+        entityManager.clear()
+
+        // Then: 30일 이전 알림만 soft delete 되어야 함
+        val updatedOldNotification = notificationRepository.findByIdIgnoreDelete(oldNotification.id)
+        val updatedRecentNotification = notificationRepository.findById(recentNotification.id).get()
+        val updatedTodayNotification = notificationRepository.findById(todayNotification.id).get()
+
+        // 30일 이전 알림은 조회되어야 함
+        assertThat(updatedOldNotification)
+            .withFailMessage("30일 이전 알림이 조회되지 않았습니다")
+            .isNotNull()
+
+        // null이 아님을 확인했으므로 안전하게 사용
+        val oldNotificationNotNull = checkNotNull(updatedOldNotification) {
+            "30일 이전 알림이 null입니다"
+        }
+
+        assertThat(oldNotificationNotNull.deletedAt)
+            .withFailMessage("30일 이전 알림의 deletedAt이 설정되지 않았습니다")
+            .isNotNull()
+
+        // 30일 이내 알림들은 그대로 유지
+        assertThat(updatedRecentNotification.deletedAt)
+            .withFailMessage("최근 알림이 삭제되었습니다")
+            .isNull()
+
+        assertThat(updatedTodayNotification.deletedAt)
+            .withFailMessage("오늘 알림이 삭제되었습니다")
+            .isNull()
+
+        // Repository 메서드로는 soft delete된 알림이 조회되지 않음 (SQLRestriction 적용)
+        val activeNotifications = notificationRepository.findAll()
+        assertThat(activeNotifications).hasSize(2)
+        assertThat(activeNotifications.map { it.title })
+            .containsExactlyInAnyOrder("최근 알림", "오늘 알림")
+    }
+
+    /**
+     * 특정 생성일시를 가진 알림을 생성하는 헬퍼 메서드
+     */
+    private fun createNotificationWithCreatedAt(title: String, createdAt: LocalDateTime): Notification {
+        val notification = Notification(
+            title = title,
+            type = NotificationType.ACTIVITY_CREATED,
+            link = "/test-link",
+            member = testMember
+        )
+
+        val savedNotification = notificationRepository.saveAndFlush(notification)
+
+        // Native query를 사용해서 created_at을 직접 업데이트 (테스트용)
+        entityManager.createNativeQuery(
+            "UPDATE notification SET created_at = ? WHERE id = ?"
+        ).apply {
+            setParameter(1, createdAt)
+            setParameter(2, savedNotification.id)
+        }.executeUpdate()
+
+        entityManager.flush()
+        entityManager.clear()
+
+        return findNotificationByIdIgnoringDeletedAt(savedNotification.id)!!
+    }
+
+    /**
+     * deleted_at 조건을 무시하고 알림을 조회하는 헬퍼 메서드
+     */
+    private fun findNotificationByIdIgnoringDeletedAt(notificationId: Long): Notification? {
+        return entityManager.createNativeQuery(
+            "SELECT * FROM notification WHERE id = ?",
+            Notification::class.java
+        ).apply {
+            setParameter(1, notificationId)
+        }.resultList.firstOrNull() as Notification?
+    }
+}


### PR DESCRIPTION
## PR 설명
[feat : 30일 지난 알림에 대해서 삭제 처리하는 배치 스케줄러 구현](https://github.com/picklab/picklab-be/commit/fe076c518f4ff7aba3008779602daa70e35fbf82)
[feat : soft delete된 entity 조회가 정상동작하지 않는 문제 해결](https://github.com/picklab/picklab-be/commit/3cae3e5ceea4ecc04cc0676e5e311d8642baae5c)

## 작업 내용

  - [x] jpa의 delete를 사용했을때에도 soft delete가 동작하도록 로직 적용
  - [x] 조회를 할때에 soft delete된 entity가 조회되는 버그 수정
  - [x] 30일이 지난 알림에 대해서 매일마다 주기적으로 삭제하는 스케줄러 구현

## 리뷰 포인트

soft delete를 구현해놓았지만 sql Restriction을 상속 구조로 적용하는 것이 동작하지 않아서 일괄적으로 수정했습니다.
스케줄러를 구현할때 spring batch를 사용할까 고민을 했지만 현재로서는 불필요하게 복잡도를 늘리는 것 같아서 간단하게 구현했습니다.
나중에 데이터 양이 많아지면 spring batch를 사용하는 것이 더 좋을 것 같습니다. 이부분에 대해서 다른 분들은 어떻게 생각하시는지 궁금합니다.

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->