### PR TITLE
fix : warning 문구가 출력되는 요소 제거

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
@@ -96,10 +96,10 @@ class ActivityService(
         if (filteredAward.isEmpty()) return null
 
         if (filteredAward.size == 1) {
-            val award = filteredAward.maxOrNull()!!
+            val curAward = filteredAward.maxOrNull() ?: throw IllegalStateException("max is null")
             return when {
-                award < 5000000 -> listOf(0, 5000000)
-                award >= 5000000 && award < 10000000 -> listOf(5000000, 10000000)
+                curAward < 5000000 -> listOf(0, 5000000)
+                curAward >= 5000000 && curAward < 10000000 -> listOf(5000000, 10000000)
                 else -> listOf(10000000, Long.MAX_VALUE)
             }
         }

--- a/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
@@ -179,7 +179,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동2",
@@ -257,7 +257,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동2",
@@ -335,7 +335,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동2",
@@ -413,7 +413,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동2",
@@ -496,7 +496,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                             ),
                         )
 
-                    val given2 =
+
                         activityRepository.save(
                             EducationActivity(
                                 title = "테스트 교육활동",
@@ -578,7 +578,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                             ),
                         )
 
-                    val given2 =
+
                         activityRepository.save(
                             EducationActivity(
                                 title = "테스트 교육활동2",
@@ -661,7 +661,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         EducationActivity(
                             title = "테스트 교육활동2",
@@ -743,7 +743,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         EducationActivity(
                             title = "테스트 교육활동2",
@@ -822,7 +822,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         CompetitionActivity(
                             title = "테스트 공모전2",
@@ -899,7 +899,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         CompetitionActivity(
                             title = "테스트 공모전2",
@@ -953,7 +953,7 @@ class ActivityIntegrationTest : IntegrationTest() {
             @Test
             @DisplayName("[성공] 활동 조회 시 마감 임박 순 정렬을 적용한다.")
             fun `마감 임박 순 정렬 테스트`() {
-                val given1 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동1",
@@ -1053,7 +1053,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val given2 =
+
                     activityRepository.save(
                         ExternalActivity(
                             title = "테스트 대외활동2",
@@ -1138,7 +1138,7 @@ class ActivityIntegrationTest : IntegrationTest() {
                         ),
                     )
 
-                val bookmark =
+
                     bookmarkRepository.save(
                         Bookmark(
                             member = member,

--- a/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
@@ -101,14 +101,14 @@ class MemberServiceTest : IntegrationTest() {
                     ),
                 )
 
-            val socialUser =
-                socialLoginRepository.save(
-                    SocialLogin(
-                        socialType = SocialType.KAKAO,
-                        socialId = "kakao12345",
-                        member = member,
-                    ),
-                )
+
+            socialLoginRepository.save(
+                SocialLogin(
+                    socialType = SocialType.KAKAO,
+                    socialId = "kakao12345",
+                    member = member,
+                ),
+            )
 
             val socialType = SocialType.KAKAO
             val userInfo =
@@ -358,7 +358,7 @@ class MemberServiceTest : IntegrationTest() {
             )
 
             // when
-            val clearedMember = memberService.clearInterestedJobCategories(member.id)
+            memberService.clearInterestedJobCategories(member.id)
 
             // then
             val interestedCategories =
@@ -815,14 +815,14 @@ class MemberServiceTest : IntegrationTest() {
         @DisplayName("[성공] 닉네임이 중복되지 않는 경우 false를 반환한다.")
         fun successCheckNicknameNotDuplicate() {
             // given
-            val member =
-                memberRepository.save(
-                    Member(
-                        name = "테스트유저",
-                        email = "test@example.com",
-                        nickname = "testNickname",
-                    ),
-                )
+
+            memberRepository.save(
+                Member(
+                    name = "테스트유저",
+                    email = "test@example.com",
+                    nickname = "testNickname",
+                ),
+            )
 
             // when
             val result = memberService.existByNickname("newNickname")
@@ -835,14 +835,14 @@ class MemberServiceTest : IntegrationTest() {
         @DisplayName("[성공] 닉네임이 중복되는 경우 true를 반환한다.")
         fun successCheckNicknameDuplicate() {
             // given
-            val member =
-                memberRepository.save(
-                    Member(
-                        name = "테스트유저",
-                        email = "test@example.com",
-                        nickname = "testNickname",
-                    ),
-                )
+
+            memberRepository.save(
+                Member(
+                    name = "테스트유저",
+                    email = "test@example.com",
+                    nickname = "testNickname",
+                ),
+            )
 
             // when
             val result = memberService.existByNickname("testNickname")


### PR DESCRIPTION
## PR 설명
[fix : warning 문구가 출력되는 요소 제거](https://github.com/picklab/picklab-be/commit/25ee0eb2b00b149ecf71851c39cc064f311f0f95)

## 작업 내용
- [x] 사용하지 않는 변수 제거
- [x] 파라미터 변수 이름과 지역 변수 이름이 동일한 로직 수정


## 리뷰 포인트

컴파일할때 warning이 많이 떠서 관련해서 수정을 좀 했습니다. 기존 로직에 이상이 없을 것으로 보이지만 같이 확인 부탁드립니다.

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->