### PR TITLE
feat : notification 일괄 삭제 기능 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -37,5 +37,6 @@ enum class SuccessCode(
     GET_RECENT_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "최근 알림 목록 조회에 성공했습니다."),
     MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
     MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
-    GET_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "읽지 않은 알림 개수 조회에 성공했습니다.")
+    DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림이 삭제되었습니다."),
+
 }

--- a/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
+++ b/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
@@ -3,7 +3,9 @@ package picklab.backend.notification.application
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import picklab.backend.member.domain.MemberService
 import picklab.backend.notification.domain.service.NotificationService
 import picklab.backend.notification.domain.service.SseEmitterService
 import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
@@ -12,7 +14,8 @@ import picklab.backend.notification.entrypoint.response.NotificationResponse
 @Component
 class NotificationUseCase(
     private val notificationService: NotificationService,
-    private val sseEmitterService: SseEmitterService
+    private val sseEmitterService: SseEmitterService,
+    private val memberService: MemberService
 ) {
 
     /**
@@ -55,5 +58,18 @@ class NotificationUseCase(
      */
     fun markAllAsRead(memberId: Long): Int {
         return notificationService.markAllAsRead(memberId)
+    }
+
+    @Transactional
+    fun deleteAllByMember(memberId: Long) {
+        val member = memberService.findActiveMember(memberId)
+        val notifications = notificationService.findAllByMember(member)
+
+        notifications.forEach {
+            it.read()
+            it.delete()
+        }
+
+        notificationService.saveAll(notifications)
     }
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/entity/Notification.kt
@@ -28,7 +28,12 @@ class Notification(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     val member: Member,
-) : SoftDeleteEntity()
+) : SoftDeleteEntity() {
+
+    fun read() {
+        isRead = true
+    }
+}
 
 enum class NotificationType {
     ACTIVITY_CREATED,

--- a/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/repository/NotificationRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import picklab.backend.member.domain.entity.Member
 import picklab.backend.notification.domain.entity.Notification
 import java.time.LocalDateTime
 
@@ -51,4 +52,6 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
 
     @Query(nativeQuery = true, value = "select * from notification where id = :id")
     fun findByIdIgnoreDelete(id: Long): Notification?
+
+    fun findAllByMember(member: Member) : List<Notification>
 }

--- a/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
@@ -1,5 +1,7 @@
 package picklab.backend.notification.domain.service
 
+import com.querydsl.core.annotations.QueryEntities
+import jakarta.persistence.Entity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -8,6 +10,7 @@ import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.common.util.logger
 import picklab.backend.member.domain.MemberService
+import picklab.backend.member.domain.entity.Member
 import picklab.backend.notification.domain.entity.Notification
 import picklab.backend.notification.domain.repository.NotificationRepository
 import picklab.backend.notification.entrypoint.request.NotificationCreateRequest
@@ -137,4 +140,6 @@ class NotificationService(
      * 특정 사용자의 모든 알림을 읽음 상태로 변경합니다
      */
     fun markAllAsRead(memberId: Long): Int = notificationRepository.markAllAsReadByMemberId(memberId)
+    fun findAllByMember(member: Member): List<Notification> = notificationRepository.findAllByMember(member)
+    fun saveAll(entities: List<Notification>): List<Notification> = notificationRepository.saveAll(entities)
 }

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.ResponseWrapper
@@ -22,9 +20,8 @@ interface NotificationApi {
         description = "실시간 알림을 받기 위한 SSE 연결을 생성합니다."
     )
     @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
-    @GetMapping("/notifications/subscribe")
     fun subscribeNotifications(
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+        memberPrincipal: MemberPrincipal
     ): SseEmitter
 
     @Operation(
@@ -32,9 +29,8 @@ interface NotificationApi {
         description = "특정 사용자에게 알림을 전송합니다."
     )
     @ApiResponse(responseCode = "200", description = "알림 전송 성공")
-    @PostMapping("/notifications/send")
     fun sendNotification(
-        @RequestBody request: NotificationCreateRequest
+        request: NotificationCreateRequest
     ): ResponseWrapper<NotificationResponse>
 
     @Operation(
@@ -42,9 +38,8 @@ interface NotificationApi {
         description = "현재 로그인한 사용자의 알림 목록을 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
-    @GetMapping("/notifications")
     fun getMyNotifications(
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        memberPrincipal: MemberPrincipal,
         pageable: Pageable
     ): ResponseWrapper<Page<NotificationResponse>>
 
@@ -53,11 +48,10 @@ interface NotificationApi {
         description = "현재 로그인한 사용자의 최근 n일 내 알림을 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "최근 알림 조회 성공")
-    @GetMapping("/notifications/recent")
     fun getRecentNotifications(
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+        memberPrincipal: MemberPrincipal,
         @Parameter(description = "조회할 일 수", example = "7")
-        @RequestParam(defaultValue = "7") days: Int
+        days: Int
     ): ResponseWrapper<List<NotificationResponse>>
 
     @Operation(
@@ -65,10 +59,9 @@ interface NotificationApi {
         description = "특정 알림을 읽음 상태로 변경합니다."
     )
     @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공")
-    @PatchMapping("/notifications/{notificationId}/read")
     fun markAsRead(
-        @Parameter(description = "알림 ID") @PathVariable notificationId: Long,
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+        @Parameter(description = "알림 ID") notificationId: Long,
+        memberPrincipal: MemberPrincipal
     ): ResponseWrapper<NotificationResponse>
 
     @Operation(
@@ -76,8 +69,16 @@ interface NotificationApi {
         description = "현재 로그인한 사용자의 모든 알림을 읽음 상태로 변경합니다."
     )
     @ApiResponse(responseCode = "200", description = "모든 알림 읽음 처리 성공")
-    @PatchMapping("/notifications/read-all")
     fun markAllAsRead(
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+        memberPrincipal: MemberPrincipal
+    ): ResponseWrapper<Unit>
+
+    @Operation(
+        summary = "사용자의 모든 알림 삭제 처리",
+        description = "현재 로그인한 사용자의 모든 알림을 삭제 처리합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "모든 알림 삭제 처리 성공")
+    fun deleteAllByMember(
+        memberPrincipal: MemberPrincipal
     ): ResponseWrapper<Unit>
 }

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
@@ -17,12 +17,14 @@ class NotificationController(
     private val notificationUseCase: NotificationUseCase
 ) : NotificationApi {
 
+    @GetMapping("/notifications/subscribe")
     override fun subscribeNotifications(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal
     ): SseEmitter {
         return notificationUseCase.subscribeNotifications(memberPrincipal.memberId)
     }
 
+    @PostMapping("/notifications/send")
     override fun sendNotification(
         @RequestBody request: NotificationCreateRequest
     ): ResponseWrapper<NotificationResponse> {
@@ -30,6 +32,7 @@ class NotificationController(
         return ResponseWrapper.success(SuccessCode.SEND_NOTIFICATION_SUCCESS, response)
     }
 
+    @GetMapping("/notifications")
     override fun getMyNotifications(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
         pageable: Pageable
@@ -38,14 +41,16 @@ class NotificationController(
         return ResponseWrapper.success(SuccessCode.GET_NOTIFICATIONS_SUCCESS, notifications)
     }
 
+    @GetMapping("/notifications/recent")
     override fun getRecentNotifications(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
-        @RequestParam(defaultValue = "30") days: Int
+        @RequestParam(defaultValue = "7") days: Int
     ): ResponseWrapper<List<NotificationResponse>> {
         val notifications = notificationUseCase.getRecentNotifications(memberPrincipal.memberId, days)
         return ResponseWrapper.success(SuccessCode.GET_RECENT_NOTIFICATIONS_SUCCESS, notifications)
     }
 
+    @PatchMapping("/notifications/{notificationId}/read")
     override fun markAsRead(
         @PathVariable notificationId: Long,
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal
@@ -54,10 +59,17 @@ class NotificationController(
         return ResponseWrapper.success(SuccessCode.MARK_NOTIFICATION_READ_SUCCESS, response)
     }
 
+    @PatchMapping("/notifications/read-all")
     override fun markAllAsRead(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal
     ): ResponseWrapper<Unit> {
         notificationUseCase.markAllAsRead(memberPrincipal.memberId)
         return ResponseWrapper.success(SuccessCode.MARK_ALL_NOTIFICATIONS_READ_SUCCESS)
+    }
+
+    @DeleteMapping("/notifications")
+    override fun deleteAllByMember(@AuthenticationPrincipal memberPrincipal: MemberPrincipal): ResponseWrapper<Unit> {
+        notificationUseCase.deleteAllByMember(memberPrincipal.memberId)
+        return ResponseWrapper.success(SuccessCode.DELETE_ALL_MEMBER_NOTIFICATION)
     }
 }

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
@@ -44,7 +44,7 @@ class NotificationController(
     @GetMapping("/notifications/recent")
     override fun getRecentNotifications(
         @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
-        @RequestParam(defaultValue = "7") days: Int
+        @RequestParam(defaultValue = "30") days: Int
     ): ResponseWrapper<List<NotificationResponse>> {
         val notifications = notificationUseCase.getRecentNotifications(memberPrincipal.memberId, days)
         return ResponseWrapper.success(SuccessCode.GET_RECENT_NOTIFICATIONS_SUCCESS, notifications)


### PR DESCRIPTION
## PR 설명

[feat : notification 일괄 삭제 기능 추가](https://github.com/picklab/picklab-be/commit/981197b935474b0c8f876f4f514e5fc1249c99b1)

## 작업 내용

- [x] 사용자 로그인 정보를 기반으로 일괄 읽음 처리 밑 삭제 기능 추가
- [x] interface에 있던 spring mvc annotation 기능들을 controller에 적용되도록 수정 

## 리뷰 포인트

삭제를 했는데 읽음 처리하지 않는 것이 이상하다고 생각되어서 동시에 되도록 처리했는데 다른 분들은 어떻게 생각하시나요?

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->