### PR TITLE
refactor : jacoco 의존성 적용 및 커버리지에 포함되면 안되는 파일 예외처리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
     id("com.google.devtools.ksp") version "1.9.25-1.0.20"
+    jacoco
 }
 
 group = "picklab"
@@ -73,4 +74,57 @@ allOpen {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+        html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
+    }
+    
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/entrypoint/request/**",
+                    "**/entrypoint/response/**",
+                    "**/domain/entity/**"
+                )
+            }
+        })
+    )
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/entrypoint/request/**",
+                    "**/entrypoint/response/**",
+                    "**/domain/entity/**"
+                )
+            }
+        })
+    )
+    
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.11"
 }


### PR DESCRIPTION
## PR 설명
[refactor : jacoco 의존성 적용 및 커버리지에 포함되면 안되는 파일 예외처리](https://github.com/picklab/picklab-be/commit/1c7a893c11350e938f1a6d2837dd71575e81985a)

## 작업 내용

- [x] JaCoCo를 이용해서 테스트 커버리지 확인이 가능하도록 처리
- [x] request, response, entity 와 같이 테스트 대상에서 제외되어야하는 클래스들 예외처리

## 리뷰 포인트

<img width="1399" height="955" alt="스크린샷 2025-07-11 오후 8 36 38" src="https://github.com/user-attachments/assets/bec05a69-d8fb-4d07-9f93-284fdf04bd4f" />
위 사진과 같이 테스트 커버리지를 확인할 수 있고 어디에 테스트가 부족한지 또는 테스트를 우리가 얼마나 잘해오고 있는지 눈으로 확인할 수 있어서 적용해보고 싶은데 의견 부탁드립니다.
## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->