### PR TITLE
♻️refactor: 이메일 전송 기능 비동기 작업으로 변경

### DIFF
--- a/src/main/kotlin/picklab/backend/auth/domain/VerificationCodeService.kt
+++ b/src/main/kotlin/picklab/backend/auth/domain/VerificationCodeService.kt
@@ -1,0 +1,17 @@
+package picklab.backend.auth.domain
+
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+
+@Service
+class VerificationCodeService(
+    private val secureRandom: SecureRandom = SecureRandom(),
+) {
+    fun createCode(): String {
+        val secureRandom = SecureRandom()
+
+        val code = secureRandom.nextInt(1000000).toString()
+
+        return code.padStart(6, '0')
+    }
+}

--- a/src/main/kotlin/picklab/backend/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package picklab.backend.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
+++ b/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
@@ -1,6 +1,7 @@
 package picklab.backend.member.application
 
 import org.springframework.stereotype.Component
+import picklab.backend.auth.domain.VerificationCodeService
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.job.application.JobUseCase
@@ -13,6 +14,7 @@ class MemberUseCase(
     private val memberService: MemberService,
     private val jobUseCase: JobUseCase,
     private val mailService: MailService,
+    private val verificationCodeService: VerificationCodeService,
 ) {
     fun updateAdditionalInfo(
         memberId: Long,
@@ -85,7 +87,7 @@ class MemberUseCase(
         if (exist != null) {
             memberService.invalidateVerificationCode(exist)
         }
-        val code = mailService.createVerificationCode()
+        val code = verificationCodeService.createCode()
         memberService.addEmailVerificationCode(memberId, request.email, code)
         mailService.sendMail(request.email, code)
     }

--- a/src/main/kotlin/picklab/backend/member/infrastructure/MailService.kt
+++ b/src/main/kotlin/picklab/backend/member/infrastructure/MailService.kt
@@ -2,13 +2,14 @@ package picklab.backend.member.infrastructure
 
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import java.security.SecureRandom
 
 @Service
 class MailService(
     private val mailSender: JavaMailSender,
 ) {
+    @Async
     fun sendMail(
         target: String,
         code: String,
@@ -18,18 +19,14 @@ class MailService(
         helper.setTo(target)
         helper.setSubject("PickLab 이메일 인증 코드")
         helper.setText(
-            "PickLab 이메일 인증 코드입니다. 인증 코드는 $code 입니다. " +
-                "인증 코드를 입력하여 이메일 인증을 완료해주세요. 코드는 5분간 유효합니다.",
-            true,
+            """
+            PickLab 이메일 인증 코드입니다.
+            인증 코드는 $code 입니다.
+            인증 코드를 입력하여 이메일 인증을 완료해주세요.
+            코드는 5분간 유효합니다.
+            """.trimIndent(),
+            false,
         )
         mailSender.send(message)
-    }
-
-    fun createVerificationCode(): String {
-        val secureRandom = SecureRandom()
-
-        val code = secureRandom.nextInt(1000000).toString()
-
-        return code.padStart(6, '0')
     }
 }


### PR DESCRIPTION
## PR 설명

- [♻️refactor: 이메일 인증 코드 생성 서비스 분리](https://github.com/picklab/picklab-be/commit/d7a1be77ca59b8b7a65c550ef9ca5d9489370379)
  - 인증 코드 생성의 경우 mailService에서 책임을 가지지 않는 것이 맞다고 판단하여 인증 도메인 내부로 위치를 변경했습니다.

- [🔧config: AsyncConfig 추가](https://github.com/picklab/picklab-be/commit/07e963d00341309dcd440b6cff7afc7b0d46931f)
  - 비동기 작업 처리를 위해 `@EnableAsync`을 적용한 설정 파일을 추가했습니다.

- [✨feat: 이메일 전송 기능](https://github.com/picklab/picklab-be/commit/17a60903fa71e492889c21f45a30c32e2f04bffd) https://github.com/async [어노테이션 추가](https://github.com/picklab/picklab-be/commit/17a60903fa71e492889c21f45a30c32e2f04bffd)

## 작업 내용

- [x] 인증 코드 생성 책임 분리
- [x] 비동기 설정 적용
- [x] 메일 전송 기능 비동기 작업 설정

## 리뷰 포인트

비동기 작업 처리를 진행하며, 예외 발생 경우에 대해서 고민을 했었습니다. 

- 비동기 예외 핸들러 적용: `AsyncUncaughtExceptionHandler` 을 상속받아 커스텀 핸들러 적용 -> 메인쓰레드로 전달이 불가능해 응답으로 사용할 수가 없음. 시스템 로그 적용 정도로만 활용 가능
- `CompletableFuture` 적용 : `CompletableFuture.get()` 메소드를 사용 시에, 완전 비동기보다는 병렬-동기 처리가 되는 것으로 확인하여 메일 전송 시 건당 평균 4~5초가 블로킹되어 적용하지 않았습니다.

결국 서버의 성능 개선을 위해 비동기 작업을 수행하였을 때, 별도의 예외처리를 적용하기보다는 사용자에게 재시도 버튼을 통해서 재시도 요청을 보내도록 하는 것이 더 효과적이지 않을까 생각해봤습니다.

이에 관해 의견들을 말씀해주시면 감사드리겠습니다.