### PR TITLE
✨feat: 리뷰와 활동 참여 스키마 엔티티 정의

### DIFF
--- a/src/main/kotlin/picklab/backend/participation/domain/entity/ActivityParticipation.kt
+++ b/src/main/kotlin/picklab/backend/participation/domain/entity/ActivityParticipation.kt
@@ -1,0 +1,45 @@
+package picklab.backend.participation.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.Comment
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+import picklab.backend.activity.domain.entity.Activity
+import picklab.backend.common.model.SoftDeleteEntity
+import picklab.backend.member.domain.entity.Member
+import picklab.backend.participation.domain.enums.ApplicationStatus
+import picklab.backend.participation.domain.enums.ProgressStatus
+
+@Entity
+@Table(name = "activity_participation")
+@SQLDelete(sql = "UPDATE activity_participation SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+class ActivityParticipation(
+    @Column(name = "application_status", length = 50, nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Comment("지원 상태 (지원 완료 / 최종 합격 / 불합격)")
+    var applicationStatus: ApplicationStatus,
+    @Column(name = "progress_status", length = 50, nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Comment("진행 상태 (진행 중 / 수료 완료 / 중도 포기)")
+    var progressStatus: ProgressStatus,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    val activity: Activity,
+) : SoftDeleteEntity() {
+    fun canWriteReview(): Boolean =
+        progressStatus == ProgressStatus.COMPLETED ||
+            progressStatus == ProgressStatus.DROPPED
+
+    fun canArchive(): Boolean = progressStatus == ProgressStatus.COMPLETED
+}

--- a/src/main/kotlin/picklab/backend/participation/domain/enums/ApplicationStatus.kt
+++ b/src/main/kotlin/picklab/backend/participation/domain/enums/ApplicationStatus.kt
@@ -1,0 +1,9 @@
+package picklab.backend.participation.domain.enums
+
+enum class ApplicationStatus(
+    val label: String,
+) {
+    APPLIED("지원 완료"),
+    ACCEPTED("최종 합격"),
+    REJECTED("불합격"),
+}

--- a/src/main/kotlin/picklab/backend/participation/domain/enums/ProgressStatus.kt
+++ b/src/main/kotlin/picklab/backend/participation/domain/enums/ProgressStatus.kt
@@ -1,0 +1,9 @@
+package picklab.backend.participation.domain.enums
+
+enum class ProgressStatus(
+    val label: String,
+) {
+    IN_PROGRESSING("진행 중"),
+    COMPLETED("수료 완료"),
+    DROPPED("중도 포기"),
+}

--- a/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
@@ -12,6 +12,7 @@ import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
+import picklab.backend.review.domain.enums.ReviewStatus
 
 @Entity
 @Table(name = "review")
@@ -48,6 +49,9 @@ class Review(
     @Column(name = "url")
     @Comment("인증 자료 URL")
     var url: String? = null,
+    @Column(name = "status")
+    @Comment("승인 여부 상태(미승인 / 승인 / 승인 중)")
+    var status: ReviewStatus,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     val member: Member,

--- a/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/entity/Review.kt
@@ -12,7 +12,7 @@ import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.common.model.SoftDeleteEntity
 import picklab.backend.member.domain.entity.Member
-import picklab.backend.review.domain.enums.ReviewStatus
+import picklab.backend.review.domain.enums.ReviewApprovalStatus
 
 @Entity
 @Table(name = "review")
@@ -49,9 +49,9 @@ class Review(
     @Column(name = "url")
     @Comment("인증 자료 URL")
     var url: String? = null,
-    @Column(name = "status")
+    @Column(name = "approval_status")
     @Comment("승인 여부 상태(미승인 / 승인 / 승인 중)")
-    var status: ReviewStatus,
+    var reviewApprovalStatus: ReviewApprovalStatus,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     val member: Member,

--- a/src/main/kotlin/picklab/backend/review/domain/enums/ReviewApprovalStatus.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/enums/ReviewApprovalStatus.kt
@@ -1,6 +1,6 @@
 package picklab.backend.review.domain.enums
 
-enum class ReviewStatus(
+enum class ReviewApprovalStatus(
     val label: String,
 ) {
     PENDING("승인 중"),

--- a/src/main/kotlin/picklab/backend/review/domain/enums/ReviewStatus.kt
+++ b/src/main/kotlin/picklab/backend/review/domain/enums/ReviewStatus.kt
@@ -1,0 +1,9 @@
+package picklab.backend.review.domain.enums
+
+enum class ReviewStatus(
+    val label: String,
+) {
+    PENDING("승인 중"),
+    APPROVED("승인"),
+    REJECTED("미승인"),
+}

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -223,6 +223,7 @@ CREATE TABLE IF NOT EXISTS review
     tips                 VARCHAR(1000)  NULL      COMMENT '꿀팁',
     job_relevance_score  TINYINT        NOT NULL  COMMENT '직무 연관성 점수',
     url                  VARCHAR(255)   NULL      COMMENT '인증 자료 URL',
+    status               VARCHAR(50)    NOT NULL  COMMENT '승인 여부 상태(미승인 / 승인 / 승인 중)',
     created_at           DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
     updated_at           DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
     deleted_at           DATETIME       NULL      COMMENT '삭제일'

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -223,7 +223,7 @@ CREATE TABLE IF NOT EXISTS review
     tips                 VARCHAR(1000)  NULL      COMMENT '꿀팁',
     job_relevance_score  TINYINT        NOT NULL  COMMENT '직무 연관성 점수',
     url                  VARCHAR(255)   NULL      COMMENT '인증 자료 URL',
-    status               VARCHAR(50)    NOT NULL  COMMENT '승인 여부 상태(미승인 / 승인 / 승인 중)',
+    approval_status      VARCHAR(50)    NOT NULL  COMMENT '승인 여부 상태(미승인 / 승인 / 승인 중)',
     created_at           DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
     updated_at           DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
     deleted_at           DATETIME       NULL      COMMENT '삭제일'

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -269,3 +269,19 @@ CREATE TABLE IF NOT EXISTS archive_upload_file_url
     updated_at               DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일'
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='아카이브 업로드 파일 URL 테이블';
+
+-- 활동 참여 테이블 생성
+-- 활동 테이블과 1(활동):N(활동 참여) 관계
+-- 멤버 테이블과 1(회원):N(활동 참여) 관계
+CREATE TABLE IF NOT EXISTS activity_participation
+(
+    id                       BIGINT         NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '활동 참여 ID',
+    member_id                BIGINT         NOT NULL COMMENT '회원 ID',
+    activity_id              BIGINT         NOT NULL COMMENT '활동 ID',
+    application_status       VARCHAR(50)    NOT NULL COMMENT '지원 상태 (지원 완료 / 최종 합격 / 불합격)',
+    progress_status          VARCHAR(50)    NOT NULL COMMENT '진행 상태 (진행 중 / 수료 완료 / 중도 포기)',
+    created_at               DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+    updated_at               DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
+    deleted_at               DATETIME       NULL     COMMENT '삭제일'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='활동 참여 테이블';

--- a/src/test/kotlin/picklab/backend/participation/domain/entity/ActivityParticipationTest.kt
+++ b/src/test/kotlin/picklab/backend/participation/domain/entity/ActivityParticipationTest.kt
@@ -1,0 +1,114 @@
+package picklab.backend.participation.domain.entity
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import picklab.backend.activity.domain.entity.Activity
+import picklab.backend.activity.domain.entity.ActivityGroup
+import picklab.backend.activity.domain.enums.OrganizerType
+import picklab.backend.activity.domain.enums.ParticipantType
+import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.member.domain.entity.Member
+import picklab.backend.participation.domain.enums.ApplicationStatus
+import picklab.backend.participation.domain.enums.ProgressStatus
+import java.time.LocalDate
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ActivityParticipationTest {
+    private lateinit var mockMember: Member
+    private lateinit var mockActivity: Activity
+
+    @BeforeEach
+    fun setup() {
+        mockMember =
+            Member(
+                name = "홍길동",
+                email = "test@example.com",
+            )
+        mockMember
+            .javaClass
+            .superclass
+            .superclass
+            .getDeclaredField("id")
+            .apply { isAccessible = true }
+            .set(mockMember, 1L)
+
+        val fixedDate = LocalDate.of(2025, 1, 1)
+        mockActivity =
+            object : Activity(
+                title = "테스트 활동",
+                organizer = OrganizerType.ETC,
+                targetAudience = ParticipantType.ALL,
+                recruitmentStartDate = fixedDate,
+                recruitmentEndDate = fixedDate,
+                startDate = fixedDate,
+                endDate = fixedDate,
+                status = RecruitmentStatus.OPEN,
+                activityGroup =
+                    ActivityGroup(
+                        name = "테스트 그룹",
+                        description = "의미 없음",
+                    ),
+            ) {}
+        mockActivity
+            .javaClass
+            .superclass
+            .superclass
+            .superclass
+            .getDeclaredField("id")
+            .apply { isAccessible = true }
+            .set(mockActivity, 1L)
+    }
+
+    @Test
+    @DisplayName("진행 중일 때는 리뷰 및 아카이브 작성이 불가능하다")
+    fun cannotWriteInProgressing() {
+        // given
+        val participation =
+            ActivityParticipation(
+                applicationStatus = ApplicationStatus.APPLIED,
+                progressStatus = ProgressStatus.IN_PROGRESSING,
+                member = mockMember,
+                activity = mockActivity,
+            )
+
+        // when & then
+        assertFalse(participation.canWriteReview())
+        assertFalse(participation.canArchive())
+    }
+
+    @Test
+    @DisplayName("수료 완료 상태는 리뷰와 아카이브 작성이 가능하다")
+    fun canWriteCompleted() {
+        // given
+        val participation =
+            ActivityParticipation(
+                applicationStatus = ApplicationStatus.APPLIED,
+                progressStatus = ProgressStatus.COMPLETED,
+                member = mockMember,
+                activity = mockActivity,
+            )
+
+        // when & then
+        assertTrue(participation.canWriteReview())
+        assertTrue(participation.canArchive())
+    }
+
+    @Test
+    @DisplayName("중도 하차 상태는 리뷰만 가능하고 아카이브는 불가능하다")
+    fun onlyReviewDropped() {
+        // given
+        val participation =
+            ActivityParticipation(
+                applicationStatus = ApplicationStatus.APPLIED,
+                progressStatus = ProgressStatus.DROPPED,
+                member = mockMember,
+                activity = mockActivity,
+            )
+
+        // when & then
+        assertTrue(participation.canWriteReview())
+        assertFalse(participation.canArchive())
+    }
+}


### PR DESCRIPTION
## PR 설명
- [✨feat: 리뷰 승인 여부 필드 추가](https://github.com/picklab/picklab-be/commit/f4f42f29150ad9ac7c23b1806269bd763c1c4155)
  - 리뷰 엔티티에 status 컬럼을 추가하고 enum으로 관리 되도록 하였습니다.
- [✨feat: 활동 참여 도메인과 스키마 추가](https://github.com/picklab/picklab-be/commit/ad09d03eb1be5ac14b804de4206f251a9d3002e5)
  - 활동 참여 테이블을 새로 추가 하였습니다.
  - 그에 맞는 상태 enum 들과 엔티티도 추가하였습니다.
- [✅test: 도메인 상태별 권한 판단 테스트 추가](https://github.com/picklab/picklab-be/commit/d017812fba7d22c0ba680c4d30c90c45e8bccbb3)
  - 도메인 로직을 간단하게 단위 테스트로 추가 하였습니다.


## 작업 내용
- [x] 리뷰에 승인 여부 상태 추가
- [x] 활동 참여 도메인 추가
- [x] 상태별 단위 테스트 추가
- [ ] 아카이브에서 관리되던 활동 상태를 활동 참여 도메인에서 관리되도록 리펙토리


## 리뷰 포인트
- 단위 테스트 같은 경우 복잡성은 낮지만 핵심적인 요소라고 생각하여 간단히 추가 했습니다.
- 활동 참여 도메인을 하위 도메인으로 가져갈지, 독립 도메인으로 가져갈지에 대한 여러 차례 고민을 하였습니다. 그러다 내린 결정은 독립 도메인으로 결정하였고, 그 이유는 다음과 같습니다.
  1. 상태 변화에 따라 시스템의 동작에 영향을 주며, 상태 기반 로직이 존재함
  2. 외부 도메인(리뷰, 아카이브)에서 직접 참조하고, 그 상태에 따라 의사결정을 하고 로직 분기가 발생함
  3. 단순히 멤버 도메인 또는 활동 도메인의 하위 개념으로 보기엔 책임이 명확히 있어보임
- 이러한 이유로 최종적으로 분리를 결정하게 되었습니다.
- 추가로 아카이브 도메인에서 `ProgressStatus`가 관리되고 있는데 제가 맡게 기획 의도를 파악한 것이라면 활동 참여 쪽에서 관리되어야 적합해 보입니다. 이에 대한 의견 부탁드려요!

## 참고 자료
- [Bounded Context & Aggregate Root](https://tech.kakaopay.com/post/backend-domain-driven-design/#step1---bounded-context--aggregate-root)