### PR TITLE
♻️refactor: CleanUp.all() 메소드 어노테이션 기반으로 테이블명을 동적으로 파악하도록 변경

### DIFF
--- a/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
@@ -28,19 +28,15 @@ import picklab.backend.activity.entrypoint.response.GetActivityDetailResponse
 import picklab.backend.activity.entrypoint.response.GetActivityListResponse
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
-import picklab.backend.helper.CleanUp
 import picklab.backend.helper.WithMockUser
 import picklab.backend.helper.extractBody
-import picklab.backend.job.template.IntegrationTest
 import picklab.backend.member.domain.entity.Member
 import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.template.IntegrationTest
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 class ActivityIntegrationTest : IntegrationTest() {
-    @Autowired
-    private lateinit var cleanUp: CleanUp
-
     @Autowired
     lateinit var activityRepository: ActivityRepository
 

--- a/src/test/kotlin/picklab/backend/auth/JwtFilterTest.kt
+++ b/src/test/kotlin/picklab/backend/auth/JwtFilterTest.kt
@@ -11,7 +11,7 @@ import picklab.backend.auth.infrastructure.JwtTokenProvider
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.helper.extractBody
-import picklab.backend.job.template.IntegrationTest
+import picklab.backend.template.IntegrationTest
 
 class JwtFilterTest : IntegrationTest() {
     @Autowired

--- a/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
@@ -22,18 +22,14 @@ import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.common.model.SuccessCode
-import picklab.backend.helper.CleanUp
 import picklab.backend.helper.WithMockUser
-import picklab.backend.job.template.IntegrationTest
 import picklab.backend.member.domain.entity.Member
 import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.template.IntegrationTest
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 class BookmarkIntegrationTest : IntegrationTest() {
-    @Autowired
-    lateinit var cleanUp: CleanUp
-
     @Autowired
     lateinit var memberRepository: MemberRepository
 

--- a/src/test/kotlin/picklab/backend/job/entrypoint/JobControllerTest.kt
+++ b/src/test/kotlin/picklab/backend/job/entrypoint/JobControllerTest.kt
@@ -12,7 +12,7 @@ import picklab.backend.helper.extractBody
 import picklab.backend.job.domain.enums.JobDetail
 import picklab.backend.job.entrypoint.response.JobDetailResponse
 import picklab.backend.job.entrypoint.response.JobResponse
-import picklab.backend.job.template.IntegrationTest
+import picklab.backend.template.IntegrationTest
 import kotlin.test.Test
 
 @WithMockUser

--- a/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
@@ -7,12 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import picklab.backend.auth.domain.OAuthUserInfo
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
-import picklab.backend.helper.CleanUp
 import picklab.backend.job.domain.JobCategoryRepository
 import picklab.backend.job.domain.entity.JobCategory
 import picklab.backend.job.domain.enums.JobDetail
 import picklab.backend.job.domain.enums.JobGroup
-import picklab.backend.job.template.IntegrationTest
 import picklab.backend.member.domain.MemberService
 import picklab.backend.member.domain.entity.*
 import picklab.backend.member.domain.enums.EmploymentType
@@ -21,12 +19,10 @@ import picklab.backend.member.domain.enums.SocialType
 import picklab.backend.member.domain.enums.WithdrawalType
 import picklab.backend.member.domain.repository.*
 import picklab.backend.member.entrypoint.request.*
+import picklab.backend.template.IntegrationTest
 import java.time.LocalDateTime
 
 class MemberServiceTest : IntegrationTest() {
-    @Autowired
-    lateinit var cleanUp: CleanUp
-
     @Autowired
     lateinit var memberService: MemberService
 
@@ -100,7 +96,6 @@ class MemberServiceTest : IntegrationTest() {
                         email = "test@example.com",
                     ),
                 )
-
 
             socialLoginRepository.save(
                 SocialLogin(

--- a/src/test/kotlin/picklab/backend/template/IntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/template/IntegrationTest.kt
@@ -1,4 +1,4 @@
-package picklab.backend.job.template
+package picklab.backend.template
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import picklab.backend.helper.CleanUp
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -18,4 +19,7 @@ abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var mapper: ObjectMapper
+
+    @Autowired
+    protected lateinit var cleanUp: CleanUp
 }

--- a/src/test/kotlin/picklab/backend/template/TestContainerConfig.kt
+++ b/src/test/kotlin/picklab/backend/template/TestContainerConfig.kt
@@ -1,4 +1,4 @@
-package picklab.backend.job.template
+package picklab.backend.template
 
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection


### PR DESCRIPTION
## PR 설명

- [♻️refactor: CleanUp.all() 메소드 어노테이션 기반으로 테이블명을 동적으로 파악하도록 변경](https://github.com/picklab/picklab-be/commit/9203613788a57d6746ecb645fd7672d0a39de721)
  - 현재 테이블명을 수동으로 설정해주어야 하기 때문에 테이블이 추가되거나 테이블명이 변경되는 경우 엔티티 작업 이외에도 테스트 환경에서도 설정해주어야 하는 불편함이 존재합니다.
  - 따라서 어노테이션 기반으로 동적으로 테이블명을 파악해서 설정을 적용할 수 있도록 변경했습니다.
  - Activity의 하위 테이블의 경우 테이블명을 별도로 설정하지 않기때문에 제외하고 파악했습니다.
  - 기존 코드 :
  ```kt
  val tables =
            listOf(
                "activity",
                "activity_group",
                "activity_job_category",
                ... // 수동으로 테이블명 기입
            )
  ```
  - 변경 이후 :
  ```kt
  entityManager.metamodel.entities
              .stream()
              .filter { entity -> entity.javaType.getAnnotation(Entity::class.java) != null }
              .filter { entity -> entity.javaType.getAnnotation(DiscriminatorValue::class.java) == null }
              .map { entity -> entity.javaType.getAnnotation(Table::class.java).name }
              .forEach { tables.add(it) } // 동적으로 테이블명 파악
  ```

- [♻️refactor: test.template 패키지 위치 변경 및 불필요한 테스트 의존성 제거](https://github.com/picklab/picklab-be/commit/db77d00f6b13f10927a6aa5367742af1be50bbd6)
  - template 패키지가 job 패키지 내부로 작성되어 있어, 공용 패키지라고 판단하여 외부로 꺼냈습니다.
  - CleanUp 클래스를 IntegrationTest 클래스에 포함시키며, 기존의 테스트에서 CleanUp을 의존하던 의존성을 제거했습니다.

## 작업 내용

- [x] `CleanUp.all()` 메소드에서 동적으로 테이블명을 파악하도록 변경
- [x] template 패키지 외부 공통 패키지로 변경
- [x] 불필요한 CleanUp 의존성 제거