### PR TITLE
✨feat: 로컬 캐시 관련 설정 추가 및 조회 수 중복 방지 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ version = "0.0.1-SNAPSHOT"
 val swaggerVersion = "2.8.8"
 val jjwtVersion = "0.12.6"
 val queryDSLVersion = "7.0"
+val archUnitVersion = "1.4.1"
+val caffeineCacheVersion = "3.2.2"
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
@@ -60,7 +62,10 @@ dependencies {
     annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDSLVersion:jakarta")
 
     // archunit
-    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.1")
+    testImplementation("com.tngtech.archunit:archunit-junit5:$archUnitVersion")
+
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine:$caffeineCacheVersion")
 }
 
 kotlin {
@@ -90,35 +95,39 @@ tasks.jacocoTestReport {
         csv.required.set(false)
         html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
     }
-    
+
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/entrypoint/request/**",
-                    "**/entrypoint/response/**",
-                    "**/domain/entity/**"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/entrypoint/request/**",
+                        "**/entrypoint/response/**",
+                        "**/domain/entity/**",
+                    )
+                }
+            },
+        ),
     )
 }
 
 tasks.jacocoTestCoverageVerification {
     dependsOn(tasks.jacocoTestReport)
-    
+
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/entrypoint/request/**",
-                    "**/entrypoint/response/**",
-                    "**/domain/entity/**"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/entrypoint/request/**",
+                        "**/entrypoint/response/**",
+                        "**/domain/entity/**",
+                    )
+                }
+            },
+        ),
     )
-    
+
     violationRules {
         rule {
             limit {

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
@@ -61,21 +61,11 @@ class ActivityUseCase(
     /**
      * 활동 ID에 해당하는 활동의 상세 데이터를 가져옵니다.
      */
-    @Transactional
     fun getActivityDetail(
         activityId: Long,
         memberId: Long?,
-        request: HttpServletRequest,
     ): GetActivityDetailResponse {
         val activity = activityService.mustFindById(activityId)
-
-        val ip = request.remoteAddr
-        val userAgent = request.getHeader("User-Agent")
-        val viewIdentifier = "activity:${activity.id}:ip:$ip:userAgent:$userAgent"
-
-        if (viewCountLimiterPort.isViewCountUpAllowed(activityId, viewIdentifier)) {
-            activityService.increaseViewCount(activity)
-        }
 
         val bookmarkCount = activityBookmarkService.countByActivityId(activityId)
         val isBookmarked = memberId?.let { activityBookmarkService.existsByMemberIdAndActivityId(memberId, activityId) } ?: false
@@ -85,5 +75,21 @@ class ActivityUseCase(
             bookmarkCount = bookmarkCount,
             isBookmarked = isBookmarked,
         )
+    }
+
+    @Transactional
+    fun increaseViewCount(
+        activityId: Long,
+        request: HttpServletRequest,
+    ) {
+        val activity = activityService.mustFindById(activityId)
+
+        val ip = request.remoteAddr
+        val userAgent = request.getHeader("User-Agent")
+        val viewIdentifier = "activity:${activity.id}:ip:$ip:userAgent:$userAgent"
+
+        if (viewCountLimiterPort.isViewCountUpAllowed(activityId, viewIdentifier)) {
+            activityService.increaseViewCount(activity)
+        }
     }
 }

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
@@ -1,7 +1,9 @@
 package picklab.backend.activity.application
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import picklab.backend.activity.application.model.ActivityItemWithBookmark
 import picklab.backend.activity.application.model.ActivitySearchCommand
 import picklab.backend.activity.domain.service.ActivityBookmarkService
@@ -13,7 +15,11 @@ import picklab.backend.activity.entrypoint.response.GetActivityListResponse
 class ActivityUseCase(
     private val activityService: ActivityService,
     private val activityBookmarkService: ActivityBookmarkService,
+    private val viewCountLimiterPort: ViewCountLimiterPort,
 ) {
+    /**
+     * 검색 필터에 일치하는 활동 리스트 및 북마크 여부를 페이징으로 가져옵니다.
+     */
     fun getActivities(
         queryParams: ActivitySearchCommand,
         size: Int,
@@ -52,12 +58,25 @@ class ActivityUseCase(
         )
     }
 
+    /**
+     * 활동 ID에 해당하는 활동의 상세 데이터를 가져옵니다.
+     */
+    @Transactional
     fun getActivityDetail(
         activityId: Long,
         memberId: Long?,
+        request: HttpServletRequest,
     ): GetActivityDetailResponse {
-        // TODO 조회수 증가 로직 추가 필요
         val activity = activityService.mustFindById(activityId)
+
+        val ip = request.remoteAddr
+        val userAgent = request.getHeader("User-Agent")
+        val viewIdentifier = "activity:${activity.id}:ip:$ip:userAgent:$userAgent"
+
+        if (viewCountLimiterPort.isViewCountUpAllowed(activityId, viewIdentifier)) {
+            activityService.increaseViewCount(activity)
+        }
+
         val bookmarkCount = activityBookmarkService.countByActivityId(activityId)
         val isBookmarked = memberId?.let { activityBookmarkService.existsByMemberIdAndActivityId(memberId, activityId) } ?: false
 
@@ -67,6 +86,4 @@ class ActivityUseCase(
             isBookmarked = isBookmarked,
         )
     }
-
-    fun mustFindActivity(activityId: Long) = activityService.mustFindActiveActivity(activityId)
 }

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
@@ -89,7 +89,7 @@ class ActivityUseCase(
         val viewIdentifier = "activity:${activity.id}:ip:$ip:userAgent:$userAgent"
 
         if (viewCountLimiterPort.isViewCountUpAllowed(activityId, viewIdentifier)) {
-            activityService.increaseViewCount(activity)
+            activity.increaseViewCount()
         }
     }
 }

--- a/src/main/kotlin/picklab/backend/activity/application/BookmarkUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/BookmarkUseCase.kt
@@ -18,7 +18,7 @@ class BookmarkUseCase(
         activityId: Long,
     ) {
         val member = memberService.findActiveMember(memberId)
-        val activity = activityService.mustFindActiveActivity(activityId)
+        val activity = activityService.mustFindById(activityId)
 
         activityBookmarkService.createActivityBookmark(member, activity)
     }
@@ -29,7 +29,7 @@ class BookmarkUseCase(
         activityId: Long,
     ) {
         val member = memberService.findActiveMember(memberId)
-        val activity = activityService.mustFindActiveActivity(activityId)
+        val activity = activityService.mustFindById(activityId)
 
         activityBookmarkService.removeActivityBookmark(member, activity)
     }

--- a/src/main/kotlin/picklab/backend/activity/application/ViewCountLimiterPort.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ViewCountLimiterPort.kt
@@ -1,6 +1,11 @@
 package picklab.backend.activity.application
 
 interface ViewCountLimiterPort {
+    companion object {
+        const val MAX_VIEW_ATTEMPTS = 10
+        const val CACHE_NAME = "activityViewCount"
+    }
+
     /**
      * 특정 활동에 대한 조회수 증가가 허용되는지 확인합니다.
      */

--- a/src/main/kotlin/picklab/backend/activity/application/ViewCountLimiterPort.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ViewCountLimiterPort.kt
@@ -1,0 +1,11 @@
+package picklab.backend.activity.application
+
+interface ViewCountLimiterPort {
+    /**
+     * 특정 활동에 대한 조회수 증가가 허용되는지 확인합니다.
+     */
+    fun isViewCountUpAllowed(
+        activityId: Long,
+        viewerIdentifier: String,
+    ): Boolean
+}

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
@@ -83,4 +83,8 @@ abstract class Activity(
     companion object {
         const val UNLIMITED_DURATION = -1
     }
+
+    fun increaseViewCount() {
+        this.viewCount++
+    }
 }

--- a/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/service/ActivityService.kt
@@ -168,11 +168,4 @@ class ActivityService(
      * 인기도는 조회수와 북마크 수를 합산하여 계산합니다.
      */
     fun getMostPopularActivity(): Activity? = activityRepository.findMostPopularActivity()
-
-    /**
-     * 활동 조회수를 증가시킵니다
-     */
-    fun increaseViewCount(activity: Activity) {
-        activity.increaseViewCount()
-    }
 }

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
@@ -65,8 +65,21 @@ interface ActivityApi {
     )
     fun getActivitiesDetail(
         @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
-        request: HttpServletRequest,
     ): ResponseEntity<ResponseWrapper<GetActivityDetailResponse>>
+
+    @Operation(
+        summary = "활동 조회수 증가",
+        description = "해당 활동의 조회수를 1 증가시킵니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "조회수 증가에 성공했습니다."),
+            ApiResponse(responseCode = "404", description = "해당 활동을 찾을 수 없습니다."),
+            ApiResponse(responseCode = "500", description = "서버 오류입니다."),
+        ],
+    )
+    fun increaseViewCount(
+        @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
+        request: HttpServletRequest,
+    ): ResponseEntity<ResponseWrapper<Unit>>
 
     @Operation(
         summary = "활동 지원",

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.ModelAttribute
@@ -64,6 +65,7 @@ interface ActivityApi {
     )
     fun getActivitiesDetail(
         @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
+        request: HttpServletRequest,
     ): ResponseEntity<ResponseWrapper<GetActivityDetailResponse>>
 
     @Operation(

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityController.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityController.kt
@@ -43,13 +43,21 @@ class ActivityController(
     @GetMapping("/{activityId}")
     override fun getActivitiesDetail(
         @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
-        request: HttpServletRequest,
     ): ResponseEntity<ResponseWrapper<GetActivityDetailResponse>> {
         val authentication = SecurityContextHolder.getContext().authentication
         val memberId: Long? = (authentication?.principal as? MemberPrincipal)?.memberId
 
-        val data = activityUseCase.getActivityDetail(activityId, memberId, request)
+        val data = activityUseCase.getActivityDetail(activityId, memberId)
         return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.GET_ACTIVITY_DETAIL, data))
+    }
+
+    @PostMapping("/{activityId}/view")
+    override fun increaseViewCount(
+        @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
+        request: HttpServletRequest,
+    ): ResponseEntity<ResponseWrapper<Unit>> {
+        activityUseCase.increaseViewCount(activityId, request)
+        return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.INCREASE_VIEW_COUNT))
     }
 
     override fun applyActivity(

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityController.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityController.kt
@@ -1,6 +1,7 @@
 package picklab.backend.activity.entrypoint
 
 import io.swagger.v3.oas.annotations.Parameter
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.context.SecurityContextHolder
@@ -42,11 +43,12 @@ class ActivityController(
     @GetMapping("/{activityId}")
     override fun getActivitiesDetail(
         @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
+        request: HttpServletRequest,
     ): ResponseEntity<ResponseWrapper<GetActivityDetailResponse>> {
         val authentication = SecurityContextHolder.getContext().authentication
         val memberId: Long? = (authentication?.principal as? MemberPrincipal)?.memberId
 
-        val data = activityUseCase.getActivityDetail(activityId, memberId)
+        val data = activityUseCase.getActivityDetail(activityId, memberId, request)
         return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.GET_ACTIVITY_DETAIL, data))
     }
 

--- a/src/main/kotlin/picklab/backend/activity/infrastructure/ViewCountLimiterAdapter.kt
+++ b/src/main/kotlin/picklab/backend/activity/infrastructure/ViewCountLimiterAdapter.kt
@@ -1,0 +1,36 @@
+package picklab.backend.activity.infrastructure
+
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Component
+import picklab.backend.activity.application.ViewCountLimiterPort
+
+/**
+ * ViewCountLimiterPort의 구현체. 추후 Redis 등의 외부 캐싱으로 전환될 가능성이 있어 별도의 구현체를 가지는 어댑터 패턴 적용
+ */
+@Component
+class ViewCountLimiterAdapter(
+    private val cacheManager: CacheManager,
+) : ViewCountLimiterPort {
+    companion object {
+        // 캐시 기간 내 최대 조회수 횟수
+        private const val MAX_VIEW_ATTEMPTS = 10
+        private const val CACHE_NAME = "activityViewCount"
+    }
+
+    override fun isViewCountUpAllowed(
+        activityId: Long,
+        viewerIdentifier: String,
+    ): Boolean {
+        val cacheKey = "activity:$activityId:$viewerIdentifier"
+        val cache = cacheManager.getCache(CACHE_NAME) ?: return true
+
+        val viewAttempt = cache.get(cacheKey) { 0 } ?: 0
+
+        if (viewAttempt < MAX_VIEW_ATTEMPTS) {
+            cache.put(cacheKey, viewAttempt + 1)
+            return true
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/picklab/backend/activity/infrastructure/ViewCountLimiterAdapter.kt
+++ b/src/main/kotlin/picklab/backend/activity/infrastructure/ViewCountLimiterAdapter.kt
@@ -3,6 +3,8 @@ package picklab.backend.activity.infrastructure
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
 import picklab.backend.activity.application.ViewCountLimiterPort
+import picklab.backend.activity.application.ViewCountLimiterPort.Companion.CACHE_NAME
+import picklab.backend.activity.application.ViewCountLimiterPort.Companion.MAX_VIEW_ATTEMPTS
 
 /**
  * ViewCountLimiterPort의 구현체. 추후 Redis 등의 외부 캐싱으로 전환될 가능성이 있어 별도의 구현체를 가지는 어댑터 패턴 적용
@@ -11,12 +13,6 @@ import picklab.backend.activity.application.ViewCountLimiterPort
 class ViewCountLimiterAdapter(
     private val cacheManager: CacheManager,
 ) : ViewCountLimiterPort {
-    companion object {
-        // 캐시 기간 내 최대 조회수 횟수
-        private const val MAX_VIEW_ATTEMPTS = 10
-        private const val CACHE_NAME = "activityViewCount"
-    }
-
     override fun isViewCountUpAllowed(
         activityId: Long,
         viewerIdentifier: String,

--- a/src/main/kotlin/picklab/backend/common/config/CacheConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/CacheConfig.kt
@@ -1,0 +1,29 @@
+package picklab.backend.common.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class CacheConfig {
+    companion object {
+        const val CACHE_MIN_DURATION = 5L
+        const val MAXIMUM_CACHE_SIZE = 10000L
+    }
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val cacheManager = CaffeineCacheManager("activityViewCount")
+        cacheManager.setCaffeine(
+            Caffeine
+                .newBuilder()
+                .expireAfterWrite(CACHE_MIN_DURATION, TimeUnit.MINUTES)
+                .maximumSize(MAXIMUM_CACHE_SIZE),
+        )
+
+        return cacheManager
+    }
+}

--- a/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
@@ -47,6 +47,7 @@ class SecurityConfig(
             authorizeHttpRequests {
                 authorize(HttpMethod.OPTIONS, "/**", permitAll)
                 readOnlyUrl.forEach { path -> authorize(HttpMethod.GET, path, permitAll) }
+                authorize(HttpMethod.POST, "/v1/activities/{activityId}/view", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -28,6 +28,7 @@ enum class SuccessCode(
     GET_ACTIVITY_DETAIL(HttpStatus.OK, "활동 상세 조회에 성공했습니다."),
     ACTIVITY_BOOKMARK_CREATED(HttpStatus.CREATED, "북마크가 추가되었습니다."),
     ACTIVITY_BOOKMARK_REMOVED(HttpStatus.OK, "북마크가 삭제되었습니다."),
+    INCREASE_VIEW_COUNT(HttpStatus.OK, "조회수 증가에 성공했습니다."),
 
     // Archive 도메인 관련
     CREATE_ARCHIVE_SUCCESS(HttpStatus.OK, "아카이브 생성에 성공했습니다."),
@@ -40,5 +41,4 @@ enum class SuccessCode(
     MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
     MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
     DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림이 삭제되었습니다."),
-
 }


### PR DESCRIPTION
## PR 설명

- [🔧config: CaffeineCache 관련 의존성 추가 및 설정파일 구성](https://github.com/picklab/picklab-be/commit/2f5a3912af42b86848e1100d214d21e919cbdebd)
  - 스프링에서 로컬 캐시 중 CaffeineCache를 사용하기 위한 설정을 적용했습니다.

- [✨feat: 조회 수 중복방지 기능 구현](https://github.com/picklab/picklab-be/commit/af33496e7cf252ae85c6ce1e35325dc1f1ab6677)
  - 캐시 관련 로직 구현체의 경우 infrastructure 패키지를 이용해 외부 기술에 대한 적용으로 적용했습니다.
  - 어댑터 패턴을 적용해, 추후 Redis 캐시로 변경하게 되었을 때에도 구현체만 변경할 수 있도록 패키지 구조를 가져갔습니다.
  - 동일 IP + User-Agent 헤더를 이용해, 동일한 기기에서의 조회수 증가를 중복방지하였습니다.
  - 기획적으로 정해진 바가 없어 임의로 5분의 기간 내에 최대 10회의 조회수를 증가시킬 수 있도록 했습니다.

### 2025/07/17 변경사항
- [✨feat: 활동 조회수 증가 로직 별도의 post 요청으로 분리](https://github.com/picklab/picklab-be/pull/38/commits/20c273b51819b4fa6d33c101e0df887eb69c1bcd)
  - 조회 수 증가의 경우 쓰기 작업이 이루어져 `GET` 요청으로 있는 것이 맞지 않다고 생각해 `POST` 요청으로 분리했습니다.

- [✅test: 기획 변경에 따른 테스트 실패 위험성 제거](https://github.com/picklab/picklab-be/pull/38/commits/70eef1ddf8eb3d2723a12ba6f8a85f4e192a9526)
  - 추후 기획이 변경될 경우 테스트 실패 위험성이 있어, repeat() 및 companion obejct를 이용하는 방식으로 변경했습니다.

## 작업 내용

- [x] 로컬 캐시 관련 의존성 추가
- [x] CaffeineCache 설정 추가
- [x] 조회수 증가 중복 방지 로직 적용

## 리뷰 포인트

- 조회수 증가의 경우, 정교한 데이터라기보다는 인기의 추세라고 생각했고, 다른 활동과의 비교를 위해 동일 유저가 짧은 시간 내에 여러 번 조회할 수 있다고 생각해서 적용해봤습니다. 추가적으로 논의해볼 부분이 있으면 의견 말씀해주시면 감사하겠습니다!

- 원경님 의견을 적용해서(제 생각에도 쿠키보다 좋다고 생각했어요 ㅎㅎ..), 유저가 변조하기 쉬운 쿠키를 이용하기 보다는 IP + User-Agent를 이용해봤습니다. 더 좋은 아이디어 있으면 공유해주시면 감사하겠습니다.

## 참고 자료

- [CaffeineCache 성능 벤치마크](https://github.com/ben-manes/caffeine/wiki/benchmarks)