### PR TITLE
✨feat: 특정 활동의 리뷰 조회 API 구현

### DIFF
--- a/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
+++ b/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
@@ -1,6 +1,5 @@
 package picklab.backend.review.application
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
@@ -10,11 +9,14 @@ import picklab.backend.common.model.ErrorCode
 import picklab.backend.common.model.PageResponse
 import picklab.backend.member.domain.MemberService
 import picklab.backend.participation.domain.service.ActivityParticipationService
+import picklab.backend.review.application.mapper.toResponse
+import picklab.backend.review.application.model.ActivityReviewListQueryRequest
 import picklab.backend.review.application.model.MyReviewListQueryRequest
 import picklab.backend.review.application.model.ReviewCreateCommand
 import picklab.backend.review.application.service.ReviewOverviewQueryService
 import picklab.backend.review.domain.policy.ReviewApprovalDecider
 import picklab.backend.review.domain.service.ReviewService
+import picklab.backend.review.entrypoint.response.ActivityReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @Component
@@ -47,7 +49,31 @@ class ReviewUseCase(
                 Sort.by("createdAt").descending(),
             )
         val page = reviewOverviewQueryService.findMyReviews(member.id, pageable)
-        val responsePage: Page<MyReviewsResponse> = page.map { MyReviewsResponse.from(it) }
+        val responsePage = page.map { MyReviewsResponse.from(it) }
+
+        return PageResponse.from(responsePage)
+    }
+
+    fun getReviewsByActivity(
+        request: ActivityReviewListQueryRequest,
+        activityId: Long,
+        memberId: Long?,
+        page: Int,
+        size: Int,
+    ): PageResponse<ActivityReviewResponse> {
+        val member = memberId?.let { memberService.findActiveMember(it) }
+        val activity = activityService.mustFindById(activityId)
+        val pageable =
+            PageRequest.of(
+                page - 1,
+                size,
+                Sort.by("createdAt").descending(),
+            )
+        val page =
+            reviewOverviewQueryService
+                .findActivityReviews(request, activity.id, pageable)
+        val isLoggedIn = member != null
+        val responsePage = page.map { it.toResponse(isLoggedIn) }
 
         return PageResponse.from(responsePage)
     }

--- a/src/main/kotlin/picklab/backend/review/application/mapper/ActivityReviewListItemMapper.kt
+++ b/src/main/kotlin/picklab/backend/review/application/mapper/ActivityReviewListItemMapper.kt
@@ -1,0 +1,20 @@
+package picklab.backend.review.application.mapper
+
+import picklab.backend.review.application.query.model.ActivityReviewListItem
+import picklab.backend.review.entrypoint.response.ActivityReviewResponse
+
+fun ActivityReviewListItem.toResponse(isLoggedIn: Boolean): ActivityReviewResponse =
+    ActivityReviewResponse(
+        id = id,
+        overallScore = overallScore,
+        infoScore = infoScore,
+        difficultyScore = difficultyScore,
+        benefitScore = benefitScore,
+        activityType = activityType,
+        participationDate = participationDate,
+        progressStatus = progressStatus,
+        summary = summary.takeIf { isLoggedIn },
+        strength = strength.takeIf { isLoggedIn },
+        weakness = weakness.takeIf { isLoggedIn },
+        tips = tips.takeIf { isLoggedIn },
+    )

--- a/src/main/kotlin/picklab/backend/review/application/model/ActivityReviewListQueryRequest.kt
+++ b/src/main/kotlin/picklab/backend/review/application/model/ActivityReviewListQueryRequest.kt
@@ -1,0 +1,12 @@
+package picklab.backend.review.application.model
+
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import picklab.backend.participation.domain.enums.ProgressStatus
+
+data class ActivityReviewListQueryRequest(
+    val rating: Int?,
+    val jobGroup: List<JobGroup>?,
+    val jobDetail: List<JobDetail>?,
+    val status: ProgressStatus?,
+)

--- a/src/main/kotlin/picklab/backend/review/application/query/ReviewOverviewQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/ReviewOverviewQueryRepository.kt
@@ -2,6 +2,8 @@ package picklab.backend.review.application.query
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import picklab.backend.review.application.model.ActivityReviewListQueryRequest
+import picklab.backend.review.application.query.model.ActivityReviewListItem
 import picklab.backend.review.application.query.model.MyReviewListItem
 
 interface ReviewOverviewQueryRepository {
@@ -9,4 +11,10 @@ interface ReviewOverviewQueryRepository {
         memberId: Long,
         pageable: Pageable,
     ): Page<MyReviewListItem>
+
+    fun findActivityReviewsWithFilter(
+        request: ActivityReviewListQueryRequest,
+        activityId: Long,
+        pageable: Pageable,
+    ): Page<ActivityReviewListItem>
 }

--- a/src/main/kotlin/picklab/backend/review/application/query/model/ActivityReviewListItem.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/model/ActivityReviewListItem.kt
@@ -1,0 +1,22 @@
+package picklab.backend.review.application.query.model
+
+import com.querydsl.core.annotations.QueryProjection
+import picklab.backend.participation.domain.enums.ProgressStatus
+import java.time.LocalDateTime
+
+data class ActivityReviewListItem
+    @QueryProjection
+    constructor(
+        val id: Long,
+        val overallScore: Int,
+        val infoScore: Int,
+        val difficultyScore: Int,
+        val benefitScore: Int,
+        val activityType: String,
+        val participationDate: LocalDateTime,
+        val progressStatus: ProgressStatus,
+        val summary: String,
+        val strength: String,
+        val weakness: String,
+        val tips: String,
+    )

--- a/src/main/kotlin/picklab/backend/review/application/service/ReviewQuerySerivce.kt
+++ b/src/main/kotlin/picklab/backend/review/application/service/ReviewQuerySerivce.kt
@@ -3,7 +3,9 @@ package picklab.backend.review.application.service
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import picklab.backend.review.application.model.ActivityReviewListQueryRequest
 import picklab.backend.review.application.query.ReviewOverviewQueryRepository
+import picklab.backend.review.application.query.model.ActivityReviewListItem
 import picklab.backend.review.application.query.model.MyReviewListItem
 
 @Service
@@ -14,4 +16,10 @@ class ReviewOverviewQueryService(
         memberId: Long,
         pageable: PageRequest,
     ): Page<MyReviewListItem> = reviewOverviewQueryRepository.findMyReviews(memberId, pageable)
+
+    fun findActivityReviews(
+        request: ActivityReviewListQueryRequest,
+        activityId: Long,
+        pageable: PageRequest,
+    ): Page<ActivityReviewListItem> = reviewOverviewQueryRepository.findActivityReviewsWithFilter(request, activityId, pageable)
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
@@ -1,15 +1,21 @@
 package picklab.backend.review.entrypoint
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import picklab.backend.archive.entrypoint.request.ReviewCreateRequest
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.PageResponse
 import picklab.backend.common.model.ResponseWrapper
-import picklab.backend.review.application.model.MyReviewListRequest
+import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
+import picklab.backend.review.entrypoint.request.MyReviewListRequest
+import picklab.backend.review.entrypoint.response.ActivityReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @Tag(name = "리뷰 API", description = "리뷰 관련 API 입니다.")
@@ -30,17 +36,44 @@ interface ReviewApi {
 
     @Operation(
         summary = "내가 작성한 리뷰 리스트 조회",
-        description =
-            "로그인한 사용자가 작성한 리뷰 리스트를 조회합니다.\n\n" +
-                "**요청 파라미터:**\n" +
-                "- size: 한번에 가져올 데이터 개수 (기본값 100)\n" +
-                "- page: 페이지 번호 (기본값 1)",
+        description = """
+        로그인한 사용자가 작성한 리뷰 리스트를 조회합니다.
+
+        요청 파라미터:
+        - size: 한번에 가져올 데이터 개수 (기본값 10)
+        - page: 페이지 번호 (기본값 1)
+        """,
         responses = [
             ApiResponse(responseCode = "200", description = "리뷰 조회에 성공했습니다."),
         ],
     )
     fun getMyReviews(
         member: MemberPrincipal,
-        request: MyReviewListRequest,
+        @ModelAttribute @ParameterObject request: MyReviewListRequest,
     ): ResponseEntity<ResponseWrapper<PageResponse<MyReviewsResponse>>>
+
+    @Operation(
+        summary = "특정 활동에 대한 리뷰 리스트 조회",
+        description = """
+        특정 활동에 대한 리뷰 리스트를 조회합니다.
+
+        요청 파라미터:
+        - page: 페이지 번호 (1부터 시작, 기본값 1)
+        - size: 한번에 가져올 데이터 개수 (1~100, 기본값 10)
+        - rating: 활동 총 평점 필터 (1~5)
+        - jobGroup: 관심 직무 필터 (대분류 전체 리스트)
+        - jobDetail: 관심 직무 필터 (세부 직무 리스트)
+        - status: 수료 상태 필터 (IN_PROGRESSING, COMPLETED, DROPPED)
+
+        로그인 여부에 따라 응답 데이터가 달라집니다.
+    """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "리뷰 조회에 성공했습니다."),
+        ],
+    )
+    fun getReviewsByActivity(
+        @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
+        member: MemberPrincipal?,
+        @ModelAttribute @ParameterObject request: ActivityReviewListRequest,
+    ): ResponseEntity<ResponseWrapper<PageResponse<ActivityReviewResponse>>>
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -15,7 +16,9 @@ import picklab.backend.common.model.PageResponse
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.review.application.ReviewUseCase
-import picklab.backend.review.application.model.MyReviewListRequest
+import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
+import picklab.backend.review.entrypoint.request.MyReviewListRequest
+import picklab.backend.review.entrypoint.response.ActivityReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @RestController
@@ -37,6 +40,23 @@ class ReviewController(
         @Valid @ModelAttribute request: MyReviewListRequest,
     ): ResponseEntity<ResponseWrapper<PageResponse<MyReviewsResponse>>> {
         val res = reviewUseCase.getMyReviews(request.toQueryRequest(member.memberId))
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseWrapper.success(SuccessCode.GET_REVIEWS, res))
+    }
+
+    @GetMapping("/v1/activities/{activityId}/reviews")
+    override fun getReviewsByActivity(
+        @PathVariable activityId: Long,
+        @AuthenticationPrincipal member: MemberPrincipal?,
+        @Valid @ModelAttribute request: ActivityReviewListRequest,
+    ): ResponseEntity<ResponseWrapper<PageResponse<ActivityReviewResponse>>> {
+        val res =
+            reviewUseCase.getReviewsByActivity(
+                request.toQueryRequest(),
+                activityId,
+                member?.memberId,
+                request.page,
+                request.size,
+            )
         return ResponseEntity.status(HttpStatus.OK).body(ResponseWrapper.success(SuccessCode.GET_REVIEWS, res))
     }
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/ActivityReviewListRequest.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/ActivityReviewListRequest.kt
@@ -1,0 +1,35 @@
+package picklab.backend.review.entrypoint.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import picklab.backend.participation.domain.enums.ProgressStatus
+import picklab.backend.review.application.model.ActivityReviewListQueryRequest
+
+data class ActivityReviewListRequest(
+    @field:Min(1)
+    @field:Schema(description = "요청 페이지 (1부터 시작)", example = "1")
+    val page: Int = 1,
+    @field:Min(1)
+    @field:Max(100)
+    @field:Schema(description = "페이지 크기", example = "10")
+    val size: Int = 10,
+    @field:Schema(description = "활동 총 평점 필터 (1~5)")
+    val rating: Int?,
+    @field:Schema(description = "관심 직무 필터 (대분류 전체 리스트)")
+    val jobGroup: List<JobGroup>?,
+    @field:Schema(description = "관심 직무 필터 (세부 직무 리스트)")
+    val jobDetail: List<JobDetail>?,
+    @field:Schema(description = "수료 상태 필터", example = "COMPLETED")
+    val status: ProgressStatus?,
+) {
+    fun toQueryRequest(): ActivityReviewListQueryRequest =
+        ActivityReviewListQueryRequest(
+            rating = this.rating,
+            jobGroup = this.jobGroup,
+            jobDetail = this.jobDetail,
+            status = this.status,
+        )
+}

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/JobCategoryFilter.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/JobCategoryFilter.kt
@@ -1,0 +1,14 @@
+package picklab.backend.review.entrypoint.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+
+data class JobCategoryFilter(
+    @field:NotNull(message = "직무 대분류는 필수 입력값입니다.")
+    @field:Schema(description = "관심 직무 대분류", example = "DEVELOPMENT")
+    val jobGroup: JobGroup,
+    @field:Schema(description = "관심 직무 세부 분류 (직무 전체일 경우 null)", example = "BACKEND")
+    val jobDetail: JobDetail? = null,
+)

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/MyReviewListRequest.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/MyReviewListRequest.kt
@@ -1,16 +1,17 @@
-package picklab.backend.review.application.model
+package picklab.backend.review.entrypoint.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import picklab.backend.review.application.model.MyReviewListQueryRequest
 
 data class MyReviewListRequest(
-    @Min(1)
-    @Schema(description = "요청 페이지 (1부터 시작)")
+    @field:Min(1)
+    @field:Schema(description = "요청 페이지 (1부터 시작)", example = "1")
     val page: Int = 1,
-    @Min(1)
-    @Max(100)
-    @Schema(description = "페이지 크기")
+    @field:Min(1)
+    @field:Max(100)
+    @field:Schema(description = "페이지 크기", example = "10")
     val size: Int = 10,
 ) {
     fun toQueryRequest(memberId: Long): MyReviewListQueryRequest =

--- a/src/main/kotlin/picklab/backend/review/entrypoint/response/ActivityReviewResponse.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/response/ActivityReviewResponse.kt
@@ -1,0 +1,53 @@
+package picklab.backend.review.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.participation.domain.enums.ProgressStatus
+import picklab.backend.review.application.query.model.ActivityReviewListItem
+import java.time.LocalDateTime
+
+@Schema(description = "리뷰 응답")
+data class ActivityReviewResponse(
+    @Schema(description = "리뷰 ID", example = "1")
+    val id: Long,
+    @Schema(description = "총 평점", example = "4")
+    val overallScore: Int,
+    @Schema(description = "직무 경험 평점", example = "4")
+    val infoScore: Int,
+    @Schema(description = "활동 강도 평점", example = "3")
+    val difficultyScore: Int,
+    @Schema(description = "혜택 및 복지 평점", example = "5")
+    val benefitScore: Int,
+    @Schema(description = "활동 유형", example = "기획")
+    val activityType: String,
+    @Schema(description = "참여 날짜", example = "2024-01-01T12:00:00")
+    val participationDate: LocalDateTime,
+    @Schema(description = "진행 상태 (진행 중 / 수료 완료 / 중도 포기)", example = "수료 완료")
+    val progressStatus: ProgressStatus,
+    // 로그인 사용자만 노출되는 필드
+    @Schema(description = "한줄평")
+    val summary: String? = null,
+    @Schema(description = "장점")
+    val strength: String? = null,
+    @Schema(description = "단점")
+    val weakness: String? = null,
+    @Schema(description = "꿀팁")
+    val tips: String? = null,
+) {
+    companion object {
+        fun from(item: ActivityReviewListItem): ActivityReviewResponse =
+            ActivityReviewResponse(
+                id = item.id,
+                overallScore = item.overallScore,
+                infoScore = item.infoScore,
+                difficultyScore = item.difficultyScore,
+                benefitScore = item.benefitScore,
+                activityType = item.activityType,
+                participationDate = item.participationDate,
+                progressStatus = item.progressStatus,
+                summary = item.summary,
+                strength = item.strength,
+                weakness = item.weakness,
+                tips = item.tips,
+            )
+    }
+}


### PR DESCRIPTION
## PR 설명
[♻️refactor: 내 활동 조회의 request DTO의 위치를 presentation 영역으로 이동](https://github.com/picklab/picklab-be/commit/8a0524ea9540d5331ce8fcb66f3216dd2abec0f2)
- presentation에 위치하는 것이 더 자연스러운 위치라고 생각하여 request DTO의 위치를 프레젠테이션 영역으로 옮겼습니다.

[✨feat: 활동별 리뷰 리스트 조회 기능 추가](https://github.com/picklab/picklab-be/commit/85fd6bb05f29e64b88195ad06c1298bd87e4c13d)
- 특정 활동 기준 리뷰 리스트 페이징 + 필터링 조회 기능 구현
- 필터링 기능 추가하였습니다. (평점, 관심 직무 대분류/세부분류, 참여 상태 등)
- `BooleanBuilder`를 통해 동적 조건절 로직 구현하였습니다.
- 로그인 여부에 따른 응답 필드를 노출시켰습니다.


## 리뷰 포인트
- 통계쿼리는 분리하여 호출하는 것이 낫다고 생각되어 리뷰 조회 API에 포함시키지 않았습니다. 추후 Review Statistics 같은 테이블로 비정규화하는 것이 좋을 것 같다 생각합니다.
- 비로그인과 로그인의 분기를 어디서 하는 것이 가장 적합할까에 대한 고민을 하였습니다.
  - 로그인 검증을 response로 매핑하는 시점으로 결정하였습니다. 시그니처에 `isLoggedIn`가 있어 충분히 설명적이지 않을까 생각하고 설계하였습니다..
- 쿼리 구현부에 아무리 고민을 많이해도 조인을 줄이거나 할 수 있는 방법이 없는 것 같습니다. 혹시 개선방법이 있다면 의견주세요!
- 응답화면에 참여 연도에 대한 구체적인 기획이 없어 그나마 연관 있다고 생각하는 필드가 활동 참여의 생성일이라 생각하여 해당 필드를 응답하도록 하였습니다. 추후 기획 요구사항에 따라 바뀌게 될 것 같습니다.