### PR TITLE
✨feat: 리뷰 단건 조회, 삭제 기능 구현

### DIFF
--- a/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
@@ -65,6 +65,7 @@ enum class ErrorCode(
      */
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 정보를 찾을 수 없습니다."),
     CANNOT_WRITE_REVIEW(HttpStatus.BAD_REQUEST, "해당 활동에 대해 리뷰를 작성할 수 없는 상태입니다."),
+    CANNOT_READ_REVIEW(HttpStatus.FORBIDDEN, "해당 리뷰를 읽을 권한이 없습니다."),
     CANNOT_UPDATE_REVIEW(HttpStatus.FORBIDDEN, "해당 리뷰를 수정할 권한이 없습니다."),
     ALREADY_EXISTS_REVIEW(HttpStatus.BAD_REQUEST, "이미 해당 활동에 대해 리뷰를 작성했습니다."),
 

--- a/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/ErrorCode.kt
@@ -67,6 +67,7 @@ enum class ErrorCode(
     CANNOT_WRITE_REVIEW(HttpStatus.BAD_REQUEST, "해당 활동에 대해 리뷰를 작성할 수 없는 상태입니다."),
     CANNOT_READ_REVIEW(HttpStatus.FORBIDDEN, "해당 리뷰를 읽을 권한이 없습니다."),
     CANNOT_UPDATE_REVIEW(HttpStatus.FORBIDDEN, "해당 리뷰를 수정할 권한이 없습니다."),
+    CANNOT_DELETE_REVIEW(HttpStatus.FORBIDDEN, "해당 리뷰를 삭제할 권한이 없습니다."),
     ALREADY_EXISTS_REVIEW(HttpStatus.BAD_REQUEST, "이미 해당 활동에 대해 리뷰를 작성했습니다."),
 
     /**

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -46,6 +46,7 @@ enum class SuccessCode(
     DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림이 삭제되었습니다."),
 
     // Review 도메인 관련
+    GET_REVIEW(HttpStatus.OK, "리뷰 단건 조회에 성공했습니다."),
     GET_REVIEWS(HttpStatus.OK, "리뷰 목록 조회에 성공했습니다."),
     CREATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 생성에 성공했습니다."),
     UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -49,7 +49,8 @@ enum class SuccessCode(
     GET_REVIEW(HttpStatus.OK, "리뷰 단건 조회에 성공했습니다."),
     GET_REVIEWS(HttpStatus.OK, "리뷰 목록 조회에 성공했습니다."),
     CREATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 생성에 성공했습니다."),
-    UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공했습니다."),
+    UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정을 성공했습니다."),
+    DELETE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 삭제를 성공했습니다."),
 
     // Search 도메인 관련
     SEARCH_AUTOCOMPLETE_SUCCESS(HttpStatus.OK, "자동완성 검색에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
+++ b/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
@@ -125,4 +125,17 @@ class ReviewUseCase(
             activity,
         )
     }
+
+    @Transactional
+    fun deleteReview(
+        memberId: Long,
+        id: Long,
+    ) {
+        val review = reviewService.mustFindById(id)
+        val member = memberService.findActiveMember(memberId)
+        if (member.id != review.member.id) {
+            throw BusinessException(ErrorCode.CANNOT_DELETE_REVIEW)
+        }
+        review.delete()
+    }
 }

--- a/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
+++ b/src/main/kotlin/picklab/backend/review/application/ReviewUseCase.kt
@@ -19,6 +19,7 @@ import picklab.backend.review.application.service.ReviewOverviewQueryService
 import picklab.backend.review.domain.policy.ReviewApprovalDecider
 import picklab.backend.review.domain.service.ReviewService
 import picklab.backend.review.entrypoint.response.ActivityReviewResponse
+import picklab.backend.review.entrypoint.response.MyReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @Component
@@ -40,6 +41,18 @@ class ReviewUseCase(
         val approvalStatus = ReviewApprovalDecider.decideOnCreate(command.url)
         val review = reviewCreateConverter.toEntity(command, approvalStatus, member, activity)
         reviewService.save(review)
+    }
+
+    fun getMyReview(
+        id: Long,
+        memberId: Long,
+    ): MyReviewResponse {
+        val review = reviewService.mustFindById(id)
+        val member = memberService.findActiveMember(memberId)
+        if (member.id != review.member.id) {
+            throw BusinessException(ErrorCode.CANNOT_READ_REVIEW)
+        }
+        return MyReviewResponse.from(review)
     }
 
     fun getMyReviews(req: MyReviewListQueryRequest): PageResponse<MyReviewsResponse> {

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import picklab.backend.archive.entrypoint.request.ReviewCreateRequest
@@ -109,5 +110,11 @@ interface ReviewApi {
         @Parameter(description = "리뷰 ID값") @PathVariable id: Long,
         member: MemberPrincipal,
         request: ReviewUpdateRequest,
+    ): ResponseEntity<ResponseWrapper<Unit>>
+
+    @Operation(summary = "리뷰 삭제", description = "본인이 작성한 리뷰를 삭제합니다.")
+    fun deleteReview(
+        @Parameter(description = "리뷰 ID값") @PathVariable id: Long,
+        @AuthenticationPrincipal member: MemberPrincipal,
     ): ResponseEntity<ResponseWrapper<Unit>>
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
@@ -17,6 +17,7 @@ import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
 import picklab.backend.review.entrypoint.request.MyReviewListRequest
 import picklab.backend.review.entrypoint.request.ReviewUpdateRequest
 import picklab.backend.review.entrypoint.response.ActivityReviewResponse
+import picklab.backend.review.entrypoint.response.MyReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @Tag(name = "리뷰 API", description = "리뷰 관련 API 입니다.")
@@ -34,6 +35,20 @@ interface ReviewApi {
         member: MemberPrincipal,
         request: ReviewCreateRequest,
     ): ResponseEntity<ResponseWrapper<Unit>>
+
+    @Operation(
+        summary = "내가 작성한 리뷰 단건 조회",
+        description = "로그인한 사용자가 본인이 작성한 특정 리뷰를 단건 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "리뷰 조회에 성공했습니다."),
+            ApiResponse(responseCode = "403", description = "해당 리뷰를 조회할 권한이 없습니다."),
+            ApiResponse(responseCode = "404", description = "리뷰 정보를 찾을 수 없습니다."),
+        ],
+    )
+    fun getMyReview(
+        @Parameter(description = "리뷰 ID값") @PathVariable id: Long,
+        member: MemberPrincipal,
+    ): ResponseEntity<ResponseWrapper<MyReviewResponse>>
 
     @Operation(
         summary = "내가 작성한 리뷰 리스트 조회",

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
@@ -21,6 +21,7 @@ import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
 import picklab.backend.review.entrypoint.request.MyReviewListRequest
 import picklab.backend.review.entrypoint.request.ReviewUpdateRequest
 import picklab.backend.review.entrypoint.response.ActivityReviewResponse
+import picklab.backend.review.entrypoint.response.MyReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewsResponse
 
 @RestController
@@ -34,6 +35,17 @@ class ReviewController(
     ): ResponseEntity<ResponseWrapper<Unit>> {
         reviewUseCase.createReview(request.toCommand(member.memberId))
         return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.CREATE_REVIEW_SUCCESS))
+    }
+
+    @GetMapping("/v1/reviews/{id}")
+    override fun getMyReview(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal member: MemberPrincipal,
+    ): ResponseEntity<ResponseWrapper<MyReviewResponse>> {
+        val res = reviewUseCase.getMyReview(id, member.memberId)
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ResponseWrapper.success(SuccessCode.GET_REVIEW, res))
     }
 
     @GetMapping("/v1/reviews")

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
@@ -82,5 +83,14 @@ class ReviewController(
     ): ResponseEntity<ResponseWrapper<Unit>> {
         reviewUseCase.updateReview(request.toCommand(id, member.memberId))
         return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.UPDATE_REVIEW_SUCCESS))
+    }
+
+    @DeleteMapping("/v1/reviews/{id}")
+    override fun deleteReview(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal member: MemberPrincipal,
+    ): ResponseEntity<ResponseWrapper<Unit>> {
+        reviewUseCase.deleteReview(member.memberId, id)
+        return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.DELETE_REVIEW_SUCCESS))
     }
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/response/MyReviewResponse.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/response/MyReviewResponse.kt
@@ -1,0 +1,44 @@
+package picklab.backend.review.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.review.domain.entity.Review
+
+@Schema(description = "내 리뷰 단건 조회 응답")
+data class MyReviewResponse(
+    @Schema(description = "총 평점")
+    val overallScore: Int,
+    @Schema(description = "정보 점수")
+    val infoScore: Int,
+    @Schema(description = "강도 점수")
+    val difficultyScore: Int,
+    @Schema(description = "혜택 점수")
+    val benefitScore: Int,
+    @Schema(description = "직무 연관성 점수")
+    val jobRelevanceScore: Int,
+    @Schema(description = "한줄 평")
+    val summary: String,
+    @Schema(description = "장점")
+    val strength: String,
+    @Schema(description = "단점")
+    val weakness: String,
+    @Schema(description = "꿀팁")
+    val tips: String?,
+    @Schema(description = "인증자료 URL")
+    val url: String?,
+) {
+    companion object {
+        fun from(review: Review): MyReviewResponse =
+            MyReviewResponse(
+                overallScore = review.overallScore,
+                infoScore = review.infoScore,
+                difficultyScore = review.difficultyScore,
+                benefitScore = review.benefitScore,
+                jobRelevanceScore = review.jobRelevanceScore,
+                summary = review.summary,
+                strength = review.strength,
+                weakness = review.weakness,
+                tips = review.tips,
+                url = review.url,
+            )
+    }
+}

--- a/src/test/kotlin/picklab/backend/review/application/UpdateReviewUnitTest.kt
+++ b/src/test/kotlin/picklab/backend/review/application/UpdateReviewUnitTest.kt
@@ -92,4 +92,66 @@ class UpdateReviewUnitTest {
         verify(exactly = 1) { memberService.findActiveMember(loggedInMemberId) }
         verify(exactly = 1) { reviewService.mustFindById(reviewId) }
     }
+
+    @Test
+    @DisplayName("로그인한 사용자와 리뷰 작성자가 다르면 조회 시 CANNOT_READ_REVIEW 에러 발생")
+    fun getReviewByNonAuthor_shouldThrowException() {
+        // given
+        val loggedInMemberId = 2L
+        val reviewId = 10L
+
+        val mockMember =
+            mockk<Member> {
+                every { id } returns loggedInMemberId
+            }
+        val mockReview =
+            mockk<Review> {
+                every { member.id } returns 1L
+            }
+
+        every { memberService.findActiveMember(loggedInMemberId) } returns mockMember
+        every { reviewService.mustFindById(reviewId) } returns mockReview
+
+        // when
+        val exception =
+            assertThrows(BusinessException::class.java) {
+                reviewUseCase.getMyReview(reviewId, loggedInMemberId)
+            }
+
+        // then
+        assert(exception.errorCode == ErrorCode.CANNOT_READ_REVIEW)
+        verify(exactly = 1) { memberService.findActiveMember(loggedInMemberId) }
+        verify(exactly = 1) { reviewService.mustFindById(reviewId) }
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자와 리뷰 작성자가 다르면 삭제 시 CANNOT_DELETE_REVIEW 에러 발생")
+    fun deleteReviewByNonAuthor_shouldThrowException() {
+        // given
+        val loggedInMemberId = 3L
+        val reviewId = 20L
+
+        val mockMember =
+            mockk<Member> {
+                every { id } returns loggedInMemberId
+            }
+        val mockReview =
+            mockk<Review> {
+                every { member.id } returns 1L
+            }
+
+        every { memberService.findActiveMember(loggedInMemberId) } returns mockMember
+        every { reviewService.mustFindById(reviewId) } returns mockReview
+
+        // when
+        val exception =
+            assertThrows(BusinessException::class.java) {
+                reviewUseCase.deleteReview(loggedInMemberId, reviewId)
+            }
+
+        // then
+        assert(exception.errorCode == ErrorCode.CANNOT_DELETE_REVIEW)
+        verify(exactly = 1) { memberService.findActiveMember(loggedInMemberId) }
+        verify(exactly = 1) { reviewService.mustFindById(reviewId) }
+    }
 }


### PR DESCRIPTION
## PR 설명
[✨feat: 리뷰 단건 조회 기능 추가](https://github.com/picklab/picklab-be/commit/42fc9dd36d2eaaa569ec276edd45c012cf2a883e)

[✨feat: 리뷰 삭제 API 추가](https://github.com/picklab/picklab-be/commit/70bbe573fa6d5a03a5af3aed889a24f13016929b)

[✅test: 리뷰 단건 조회, 삭제 단위 테스트 추가](https://github.com/picklab/picklab-be/commit/e331d6447982fe1dfac6ba79eeb94cca036a9469)

## 리뷰 포인트
- 단순 CRUD 성격이라 하나의 PR로 묶었습니다.
- 단건 조회 응답 DTO가 도메인 엔티티를 직접 참조하도록 구성했습니다.  
허용했던 가장 큰 이유는 DIP를 위반하지 않는다는 것이고, 클린 아키텍처의 저자가 언급한
"복잡도를 줄이는 게 더 가치 있다면, 규칙을 과하게 적용하지 않아도 된다." 는 원칙에도 부합하다 생각하여 계층 관통을 허용하였습니다.
- 삭제 기능에서는 `Review.delete()` 호출을 유즈케이스에서 직접 처리하도록 했습니다.  
별도로 서비스에 위임할 정도의 비즈니스 로직이 없어 보였기 때문입니다.