### PR TITLE
✨feat: 최근 본 활동 조회 기능 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
@@ -20,4 +20,9 @@ interface ActivityQueryRepository {
         queryData: GetMyBookmarkListCondition,
         pageable: PageRequest,
     ): Page<ActivityItem>
+
+    fun findRecentlyViewedActivities(
+        memberId: Long,
+        pageable: PageRequest,
+    ): Page<ActivityItem>
 }

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
@@ -13,8 +13,6 @@ interface ActivityQueryRepository {
 
     fun findPopularActivities(pageable: PageRequest): Page<ActivityItem>
 
-    fun findActivityItemByActivityIds(activityIds: List<Long>): List<ActivityItem>
-
     fun findActivityItemByMemberBookmarked(
         memberId: Long,
         queryData: GetMyBookmarkListCondition,

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityQueryService.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityQueryService.kt
@@ -20,4 +20,9 @@ class ActivityQueryService(
         queryData: GetMyBookmarkListCondition,
         pageable: PageRequest,
     ): Page<ActivityItem> = activityQueryRepository.findActivityItemByMemberBookmarked(memberId, queryData, pageable)
+
+    fun getRecentlyViewedActivities(
+        memberId: Long,
+        pageable: PageRequest,
+    ): Page<ActivityItem> = activityQueryRepository.findRecentlyViewedActivities(memberId, pageable)
 }

--- a/src/main/kotlin/picklab/backend/activity/application/model/RecentlyViewedActivitiesCondition.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/model/RecentlyViewedActivitiesCondition.kt
@@ -1,0 +1,7 @@
+package picklab.backend.activity.application.model
+
+class RecentlyViewedActivitiesCondition(
+    val memberId: Long,
+    val page: Int,
+    val size: Int,
+)

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
@@ -72,15 +72,15 @@ interface ActivityApi {
     ): ResponseEntity<ResponseWrapper<GetActivityDetailResponse>>
 
     @Operation(
-        summary = "활동 조회수 증가",
-        description = "해당 활동의 조회수를 1 증가시킵니다.",
+        summary = "활동 조회 기록",
+        description = "활동 조회를 기록합니다. 조회수를 증가시키고 로그인한 사용자의 경우 조회 이력도 저장됩니다.",
         responses = [
-            ApiResponse(responseCode = "200", description = "조회수 증가에 성공했습니다."),
+            ApiResponse(responseCode = "200", description = "활동 조회 기록에 성공했습니다."),
             ApiResponse(responseCode = "404", description = "해당 활동을 찾을 수 없습니다."),
             ApiResponse(responseCode = "500", description = "서버 오류입니다."),
         ],
     )
-    fun increaseViewCount(
+    fun recordActivityView(
         @Parameter(description = "활동 ID값") @PathVariable activityId: Long,
         request: HttpServletRequest,
     ): ResponseEntity<ResponseWrapper<Unit>>
@@ -105,6 +105,18 @@ interface ActivityApi {
         ],
     )
     fun getWeeklyPopularActivities(
+        @Valid @ModelAttribute request: GetActivityPageRequest,
+    ): ResponseEntity<ResponseWrapper<PageResponse<ActivityItemWithBookmark>>>
+
+    @Operation(
+        summary = "최근 본 활동 조회",
+        description = "유저가 최근에 본 활동을 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "최근 본 활동 조회에 성공했습니다."),
+        ],
+    )
+    fun getRecentlyViewedActivities(
+        @AuthenticationPrincipal member: MemberPrincipal,
         @Valid @ModelAttribute request: GetActivityPageRequest,
     ): ResponseEntity<ResponseWrapper<PageResponse<ActivityItemWithBookmark>>>
 }

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/mapper/ActivityPageRequestMapper.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/mapper/ActivityPageRequestMapper.kt
@@ -1,6 +1,7 @@
 package picklab.backend.activity.entrypoint.mapper
 
 import picklab.backend.activity.application.model.PopularActivitiesCondition
+import picklab.backend.activity.application.model.RecentlyViewedActivitiesCondition
 import picklab.backend.activity.application.model.RecommendActivitiesCondition
 import picklab.backend.activity.entrypoint.request.GetActivityPageRequest
 
@@ -13,6 +14,13 @@ fun GetActivityPageRequest.toPopularActivitiesCondition(memberId: Long?): Popula
 
 fun GetActivityPageRequest.toRecommendActivitiesCondition(memberId: Long): RecommendActivitiesCondition =
     RecommendActivitiesCondition(
+        memberId = memberId,
+        page = page,
+        size = size,
+    )
+
+fun GetActivityPageRequest.toRecentlyViewedActivitiesCondition(memberId: Long): RecentlyViewedActivitiesCondition =
+    RecentlyViewedActivitiesCondition(
         memberId = memberId,
         page = page,
         size = size,

--- a/src/main/kotlin/picklab/backend/activity/infrastructure/ActivityQueryRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/activity/infrastructure/ActivityQueryRepositoryImpl.kt
@@ -190,37 +190,6 @@ class ActivityQueryRepositoryImpl(
         return PageImpl(items, pageable, count)
     }
 
-    override fun findActivityItemByActivityIds(activityIds: List<Long>): List<ActivityItem> {
-        if (activityIds.isEmpty()) {
-            return emptyList()
-        }
-
-        return jpaQueryFactory
-            .selectFrom(QActivity.activity)
-            .leftJoin(QActivityJobCategory.activityJobCategory)
-            .on(
-                QActivityJobCategory.activityJobCategory.activity.id
-                    .eq(QActivity.activity.id),
-            ).leftJoin(QJobCategory.jobCategory)
-            .on(
-                QActivityJobCategory.activityJobCategory.jobCategory.id
-                    .eq(QJobCategory.jobCategory.id),
-            ).where(QActivity.activity.id.`in`(activityIds))
-            .transform(
-                GroupBy.groupBy(QActivity.activity.id).list(
-                    QActivityItem(
-                        QActivity.activity.id,
-                        QActivity.activity.title,
-                        QActivity.activity.organizer.stringValue(),
-                        QActivity.activity.startDate,
-                        QActivity.activity.activityType,
-                        GroupBy.list(QJobCategory.jobCategory.jobDetail.stringValue()),
-                        QActivity.activity.activityThumbnailUrl,
-                    ),
-                ),
-            )
-    }
-
     override fun findActivityItemByMemberBookmarked(
         memberId: Long,
         queryData: GetMyBookmarkListCondition,

--- a/src/main/kotlin/picklab/backend/member/domain/entity/MemberActivityViewHistory.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/entity/MemberActivityViewHistory.kt
@@ -1,0 +1,24 @@
+package picklab.backend.member.domain.entity
+
+import jakarta.persistence.*
+import picklab.backend.activity.domain.entity.Activity
+import picklab.backend.common.model.BaseEntity
+
+@Entity
+@Table(
+    name = "member_activity_view_history",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_member_activity_view",
+            columnNames = ["member_id", "activity_id"],
+        ),
+    ],
+)
+class MemberActivityViewHistory(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    val activity: Activity,
+) : BaseEntity()

--- a/src/main/kotlin/picklab/backend/member/domain/repository/MemberActivityViewHistoryRepository.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/repository/MemberActivityViewHistoryRepository.kt
@@ -1,0 +1,25 @@
+package picklab.backend.member.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import picklab.backend.member.domain.entity.MemberActivityViewHistory
+import java.time.LocalDateTime
+
+interface MemberActivityViewHistoryRepository : JpaRepository<MemberActivityViewHistory, Long> {
+    @Modifying
+    @Query(
+        """
+        INSERT INTO member_activity_view_history (member_id, activity_id, created_at, updated_at) 
+        VALUES (:memberId, :activityId, :now, :now)
+        ON DUPLICATE KEY UPDATE updated_at = :now
+    """,
+        nativeQuery = true,
+    )
+    fun upsertViewHistory(
+        @Param("memberId") memberId: Long,
+        @Param("activityId") activityId: Long,
+        @Param("now") now: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/picklab/backend/member/domain/service/MemberActivityViewHistoryService.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/service/MemberActivityViewHistoryService.kt
@@ -1,0 +1,20 @@
+package picklab.backend.member.domain.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.member.domain.repository.MemberActivityViewHistoryRepository
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class MemberActivityViewHistoryService(
+    private val memberActivityViewHistoryRepository: MemberActivityViewHistoryRepository,
+) {
+    fun recordActivityView(
+        memberId: Long,
+        activityId: Long,
+        targetDate: LocalDateTime,
+    ) {
+        memberActivityViewHistoryRepository.upsertViewHistory(memberId, activityId, targetDate)
+    }
+}

--- a/src/main/resources/db/migration/V1.6__create_member_activity_view_history_table.sql
+++ b/src/main/resources/db/migration/V1.6__create_member_activity_view_history_table.sql
@@ -1,0 +1,14 @@
+-- 회원 활동 조회 이력 테이블 생성
+CREATE TABLE IF NOT EXISTS member_activity_view_history
+(
+    id          BIGINT   NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '검색 기록 ID',
+    member_id   BIGINT   NOT NULL COMMENT '검색한 회원 ID',
+    activity_id BIGINT   NOT NULL COMMENT '활동 ID',
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='회원 활동 조회 이력 테이블';
+
+-- 중복 조회를 방지하기 위한 유니크 제약조건 추가
+ALTER TABLE member_activity_view_history
+    ADD CONSTRAINT uk_member_activity_view UNIQUE (member_id, activity_id);


### PR DESCRIPTION
## PR 설명

- [✨feat: 회원 활동 이력 스키마 생성](https://github.com/picklab/picklab-be/commit/941fcc33fc8fe1863bae84845d42990872126e68)
  - 기획적으로 정해져 있는 것이 없는 상태에서, 초기에는 클라이언트측에서 저장하고 id값들을 받는 방식을 생각했었습니다.
  - 하지만 모든 id값을 매번 받게 되면 백엔드에서 페이징 관리가 된다고 생각하지 않았고, 브라우저 변경 시 초기화 등의 이유을 고려해봤을 때 별도의 테이블로 관리하는 것이 더 낫다고 판단했습니다.
  - 단순 이력이기 때문에 soft delete를 적용하지 않았으며, 같은 게시글을 다시 조회 시 updated_at을 최신화하는 방식을 통해 최근 본 게시글을 판단할 수 있도록 하고자 의도했습니다.
  - 한 명의 회원이 한 개의 게시글을 여러번 조회했을 때 이를 모두 기록해야하는지 생각해봤을 때, 현재는 불필요하다고 생각해 유니크 인덱스를 생성했습니다.

- [✨feat: 최근 본 활동 조회 기능 추가](https://github.com/picklab/picklab-be/commit/d328c66333ae625be989b18ac1862202243af92e)
  - 활동 조회의 경우 `GET` 요청이기 때문에 활동 이력을 남기는 트랜잭션을 사용하는 것은 조회수 때와 같이 RESTful 하지 않다고 생각했습니다.
  - 이에 따라 조회수 증가 로직에 회원일 경우 활동 조회 이력을 남기도록 했고, 이에 맞게 메소드명을 `increase` -> `record` 로 변경했습니다.
  - Unique 인덱스 적용에 따라, 같은 게시글을 조회 시 updated_at을 최신화하기 위해 upsert 기능을 적용했습니다.

## 작업 내용

- [x] 회원 활동 이력 스키마 작성
- [x] 게시글 상세보기 POST 요청 시, 조회 수 뿐만 아니라 로그인 유저의 경우 활동 이력도 증가하도록 기능 작성
- [x] 최근 본 활동 기록 조회 쿼리 자성

## 리뷰 포인트
- 활동 이력 테이블인데, 한 유저가 같은 게시글을 여러 번 클릭해도 모두 남겨야할지 말아야할지 고민하다가 남기지 않는 방향으로 선택했습니다. 의견을 여쭤보고 싶습니다.

- 메소드명을 단순 조회수 증가에서 조회 시 저장의 느낌을 주기 위해 `recordActivityView` 로 선택하였는데, 기능을 전부 표현하지 못하는 것 같습니다...