### PR TITLE
💚cd: 배포 파이프라인 이전(GCP -> NCP)

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -18,8 +18,8 @@ permissions:
   contents: read
 
 jobs:
-  docker-build-push-deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  docker-build-push:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     name: Create Docker Image
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +28,6 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_REPO_TOKEN }}
-
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -58,28 +57,38 @@ jobs:
           docker push ${{ secrets.DOCKER_REPO }}:latest
           docker push ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha }}
 
-      - name: Google Auth
-        id: "auth"
-        uses: "google-github-actions/auth@v1"
+  deploy-to-ncp:
+    needs: docker-build-push
+    name: Deploy to NCP Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository with submodules for deploy files
+        uses: actions/checkout@v4
         with:
-          credentials_json: ${{ secrets.GCE_SA_KEY }}
+          submodules: recursive
+          token: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
-      - name: set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v1"
+      - name: Copy deploy files to NCP server
+        uses: appleboy/scp-action@v1.0.0
         with:
-          project_id: ${{ secrets.GCE_PROJECT_ID }}
+          host: ${{ secrets.NCP_SERVER_IP }}
+          username: ${{ secrets.NCP_USERNAME }}
+          key: ${{ secrets.NCP_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.NCP_SSH_PORT }}
+          source: ${{ secrets.DEPLOY_SCRIPT_PATH }}
+          target: "."
+          strip_components: 4
 
-      - name: Copy .env and deploy script to GCP VM
-        run: |
-          gcloud compute scp ${{ secrets.PRIVATE_DEPLOY_FILE }} ${{ secrets.GCE_USERNAME }}@${{ secrets.GCE_INSTANCE_NAME }}:${{ secrets.DEPLOY_FILE }} \
-            --zone=${{ secrets.GCE_INSTANCE_ZONE }} --quiet
-
-      - name: Deploy to GCE VM Instance
-        run: |
-          gcloud compute ssh ${{ secrets.GCE_USERNAME }}@${{ secrets.GCE_INSTANCE_NAME }} \
-            --zone=${{ secrets.GCE_INSTANCE_ZONE }} \
-            --command="chmod +x ${{ secrets.DEPLOY_FILE }} && \
-              bash ${{ secrets.DEPLOY_FILE }} \
+      - name: Deploy to NCP Server
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.NCP_SERVER_IP }}
+          username: ${{ secrets.NCP_USERNAME }}
+          key: ${{ secrets.NCP_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.NCP_SSH_PORT }}
+          script: |
+            chmod +x ${{ secrets.DEPLOY_FILE }} && \
+            bash ${{ secrets.DEPLOY_FILE }} \
               ${{ secrets.APP_NAME }} \
               ${{ secrets.DOCKER_REPO }} \
-              ${{ github.event.workflow_run.head_sha }}"
+              ${{ github.sha }}

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -46,16 +46,16 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: build docker
-        run: ./gradlew bootBuildImage --imageName=${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha }}
+        run: ./gradlew bootBuildImage --imageName=${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Tag Version
         run: |
-          docker tag ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha }} ${{ secrets.DOCKER_REPO }}:latest
+          docker tag ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }} ${{ secrets.DOCKER_REPO }}:latest
 
       - name: Publish Docker Images
         run: |
           docker push ${{ secrets.DOCKER_REPO }}:latest
-          docker push ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha }}
+          docker push ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }}
 
   deploy-to-ncp:
     needs: docker-build-push
@@ -91,4 +91,4 @@ jobs:
             bash ${{ secrets.DEPLOY_FILE }} \
               ${{ secrets.APP_NAME }} \
               ${{ secrets.DOCKER_REPO }} \
-              ${{ github.sha }}
+              ${{ github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
## PR 설명

- [💚cd: 배포 파이프라인 이전(GCP -> NCP)](https://github.com/picklab/picklab-be/commit/83d1a3d1b6333acd728581341e3982beb4b12485)
  - 기존 GCP 서버 만료됨에 따라 서버가 내려가, 새로 네이버 클라우드를 통해 서버를 옮겼습니다.
  - 이에 따라, 기존 CD 파이프라인 또한 NCP 서버로 옮기는 작업을 진행했습니다.
  - ssh 통신에 사용되는 appleboy/scp-actions, ssh-actions 최신 버전으로 업그레이드 했습니다.
  - 이미지 빌드 및 도커 푸쉬 / SSH 통신을 통한 배포파일 이전 및 도커 실행 2단계의 job으로 구분해 re-run 시 docker 파일 빌드를 계속하는 문제를 해결했습니다.
  - `workflow_dispatch` 이벤트를 추가해, 수동으로 워크플로우 파일을 실행시킬 수 있도록 설정했습니다.

## 작업 내용

- [x] 배포 파이프라인 이전 워크플로우 파일 작성
- [x] 별도의 스테이징 브랜치를 통한 워크플로우 유효성 테스트

## 리뷰 포인트

- 파이프라인 관련 작업이어서 별도의 리뷰 포인트는 없습니다. 궁금하신 점 남겨주시면 답변 달 수 있도록 하겠습니다!