### PR TITLE
✨feat: 리뷰 통계 관련 조회 기능 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
@@ -34,6 +34,7 @@ class SecurityConfig(
             "/v1/activities",
             "/v1/activities/**",
             "/v1/search/autocomplete",
+            "/v1/activities/*/reviews/statistics/**",
         )
 
     @Bean

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -50,6 +50,7 @@ enum class SuccessCode(
     UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정을 성공했습니다."),
     DELETE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 삭제를 성공했습니다."),
     GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS(HttpStatus.OK, "직무 연관성 평균 점수 조회에 성공했습니다."),
+    GET_SATISFACTION_AVG_SCORES_SUCCESS(HttpStatus.OK, "활동별 만족도 통계 조회에 성공했습니다."),
 
     // Search 도메인 관련
     SEARCH_AUTOCOMPLETE_SUCCESS(HttpStatus.OK, "자동완성 검색에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -49,6 +49,7 @@ enum class SuccessCode(
     CREATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 생성에 성공했습니다."),
     UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정을 성공했습니다."),
     DELETE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 삭제를 성공했습니다."),
+    GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS(HttpStatus.OK, "직무 연관성 평균 점수 조회에 성공했습니다."),
 
     // Search 도메인 관련
     SEARCH_AUTOCOMPLETE_SUCCESS(HttpStatus.OK, "자동완성 검색에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/review/application/ReviewStatisticsUseCase.kt
+++ b/src/main/kotlin/picklab/backend/review/application/ReviewStatisticsUseCase.kt
@@ -2,16 +2,31 @@ package picklab.backend.review.application
 
 import org.springframework.stereotype.Component
 import picklab.backend.activity.domain.service.ActivityService
+import picklab.backend.member.domain.MemberService
 import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.application.query.model.SatisfactionStatisticsItem
 import picklab.backend.review.application.service.ReviewStatisticsQueryService
 
 @Component
 class ReviewStatisticsUseCase(
     private val activityService: ActivityService,
     private val reviewStatisticsQueryService: ReviewStatisticsQueryService,
+    private val memberService: MemberService,
 ) {
     fun getJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem {
         val activity = activityService.mustFindById(activityId)
         return reviewStatisticsQueryService.getJobRelevanceStatistics(activity.id)
+    }
+
+    fun getSatisfactionStatistics(
+        memberId: Long?,
+        activityId: Long,
+    ): List<SatisfactionStatisticsItem> {
+        val activity = activityService.mustFindById(activityId)
+        val jobCategoryIds =
+            memberId?.let {
+                memberService.findMyInterestedJobCategoryIds(memberService.findActiveMember(it))
+            } ?: emptyList()
+        return reviewStatisticsQueryService.getSatisfactionStatistics(activity.id, jobCategoryIds)
     }
 }

--- a/src/main/kotlin/picklab/backend/review/application/ReviewStatisticsUseCase.kt
+++ b/src/main/kotlin/picklab/backend/review/application/ReviewStatisticsUseCase.kt
@@ -1,0 +1,17 @@
+package picklab.backend.review.application
+
+import org.springframework.stereotype.Component
+import picklab.backend.activity.domain.service.ActivityService
+import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.application.service.ReviewStatisticsQueryService
+
+@Component
+class ReviewStatisticsUseCase(
+    private val activityService: ActivityService,
+    private val reviewStatisticsQueryService: ReviewStatisticsQueryService,
+) {
+    fun getJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem {
+        val activity = activityService.mustFindById(activityId)
+        return reviewStatisticsQueryService.getJobRelevanceStatistics(activity.id)
+    }
+}

--- a/src/main/kotlin/picklab/backend/review/application/query/ReviewStatisticsQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/ReviewStatisticsQueryRepository.kt
@@ -1,7 +1,13 @@
 package picklab.backend.review.application.query
 
 import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.application.query.model.SatisfactionStatisticsItem
 
 interface ReviewStatisticsQueryRepository {
     fun findJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem
+
+    fun findSatisfactionStatistics(
+        activityId: Long,
+        jobCategoryIds: List<Long>,
+    ): List<SatisfactionStatisticsItem>
 }

--- a/src/main/kotlin/picklab/backend/review/application/query/ReviewStatisticsQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/ReviewStatisticsQueryRepository.kt
@@ -1,0 +1,7 @@
+package picklab.backend.review.application.query
+
+import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+
+interface ReviewStatisticsQueryRepository {
+    fun findJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem
+}

--- a/src/main/kotlin/picklab/backend/review/application/query/model/JobRelevanceStatisticsItem.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/model/JobRelevanceStatisticsItem.kt
@@ -1,0 +1,13 @@
+package picklab.backend.review.application.query.model
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class JobRelevanceStatisticsItem
+    @QueryProjection
+    constructor(
+        val planningAvgScore: Double,
+        val developmentAvgScore: Double,
+        val marketingAvgScore: Double,
+        val aiAvgScore: Double,
+        val designAvgScore: Double,
+    )

--- a/src/main/kotlin/picklab/backend/review/application/query/model/SatisfactionStatisticsItem.kt
+++ b/src/main/kotlin/picklab/backend/review/application/query/model/SatisfactionStatisticsItem.kt
@@ -1,0 +1,16 @@
+package picklab.backend.review.application.query.model
+
+import com.querydsl.core.annotations.QueryProjection
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+
+data class SatisfactionStatisticsItem
+    @QueryProjection
+    constructor(
+        val jobGroup: JobGroup?,
+        val jobDetail: JobDetail?,
+        val avgTotalScore: Double,
+        val avgJobExperienceScore: Double,
+        val avgActivityIntensityScore: Double,
+        val avgBenefitScore: Double,
+    )

--- a/src/main/kotlin/picklab/backend/review/application/service/ReviewStatisticsQueryService.kt
+++ b/src/main/kotlin/picklab/backend/review/application/service/ReviewStatisticsQueryService.kt
@@ -3,6 +3,7 @@ package picklab.backend.review.application.service
 import org.springframework.stereotype.Service
 import picklab.backend.review.application.query.ReviewStatisticsQueryRepository
 import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.application.query.model.SatisfactionStatisticsItem
 
 @Service
 class ReviewStatisticsQueryService(
@@ -10,4 +11,9 @@ class ReviewStatisticsQueryService(
 ) {
     fun getJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem =
         reviewStatisticsQueryRepository.findJobRelevanceStatistics(activityId)
+
+    fun getSatisfactionStatistics(
+        activityId: Long,
+        jobCategoryIds: List<Long>,
+    ): List<SatisfactionStatisticsItem> = reviewStatisticsQueryRepository.findSatisfactionStatistics(activityId, jobCategoryIds)
 }

--- a/src/main/kotlin/picklab/backend/review/application/service/ReviewStatisticsQueryService.kt
+++ b/src/main/kotlin/picklab/backend/review/application/service/ReviewStatisticsQueryService.kt
@@ -1,0 +1,13 @@
+package picklab.backend.review.application.service
+
+import org.springframework.stereotype.Service
+import picklab.backend.review.application.query.ReviewStatisticsQueryRepository
+import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+
+@Service
+class ReviewStatisticsQueryService(
+    private val reviewStatisticsQueryRepository: ReviewStatisticsQueryRepository,
+) {
+    fun getJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem =
+        reviewStatisticsQueryRepository.findJobRelevanceStatistics(activityId)
+}

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsApi.kt
@@ -5,9 +5,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
+import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.review.entrypoint.response.JobRelevanceStatisticsResponse
+import picklab.backend.review.entrypoint.response.SatisfactionStatisticsResponse
 
 @Tag(name = "리뷰 통계 API", description = "리뷰 통계 관련 API 입니다.")
 interface ReviewStatisticsApi {
@@ -23,4 +26,22 @@ interface ReviewStatisticsApi {
     fun getJobRelevanceStatistics(
         @PathVariable activityId: Long,
     ): ResponseEntity<ResponseWrapper<JobRelevanceStatisticsResponse>>
+
+    @Operation(
+        summary = "활동별 만족도 평가 평균 점수 조회",
+        description = """
+활동에 대한 전체 리뷰와 로그인 사용자의 관심 직무별 만족도 평가 평균 점수를 반환합니다.
+- 비로그인(인증되지 않은) 상태일 경우: 전체 리뷰에 대한 통계만 노출됩니다.
+- 로그인 상태일 경우: 전체 리뷰 통계와 함께 사용자가 등록한 최대 5개 관심 직무별 통계도 같이 반환됩니다.
+""",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "활동별 만족도 통계 조회에 성공했습니다."),
+        ],
+    )
+    fun getSatisfactionStatistics(
+        @AuthenticationPrincipal member: MemberPrincipal?,
+        @PathVariable activityId: Long,
+    ): ResponseEntity<ResponseWrapper<SatisfactionStatisticsResponse>>
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsApi.kt
@@ -1,0 +1,26 @@
+package picklab.backend.review.entrypoint
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import picklab.backend.common.model.ResponseWrapper
+import picklab.backend.review.entrypoint.response.JobRelevanceStatisticsResponse
+
+@Tag(name = "리뷰 통계 API", description = "리뷰 통계 관련 API 입니다.")
+interface ReviewStatisticsApi {
+    @Operation(
+        summary = "활동별 직무 연관성 점수 평균 조회",
+        description = "활동에 대한 전체 리뷰를 집계해 직무별 평균 연관성 점수 반환합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "직무 연관성 평균 점수 조회에 성공했습니다."),
+        ],
+    )
+    fun getJobRelevanceStatistics(
+        @PathVariable activityId: Long,
+    ): ResponseEntity<ResponseWrapper<JobRelevanceStatisticsResponse>>
+}

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsController.kt
@@ -1,13 +1,16 @@
 package picklab.backend.review.entrypoint
 
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
+import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.review.application.ReviewStatisticsUseCase
 import picklab.backend.review.entrypoint.response.JobRelevanceStatisticsResponse
+import picklab.backend.review.entrypoint.response.SatisfactionStatisticsResponse
 import picklab.backend.review.entrypoint.response.toResponse
 
 @RestController
@@ -22,5 +25,17 @@ class ReviewStatisticsController(
             .getJobRelevanceStatistics(activityId)
             .toResponse()
             .let { ResponseWrapper.success(SuccessCode.GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS, it) }
+            .let { ResponseEntity.ok(it) }
+
+    @GetMapping("/v1/activities/{activityId}/reviews/statistics/satisfaction")
+    override fun getSatisfactionStatistics(
+        @AuthenticationPrincipal member: MemberPrincipal?,
+        @PathVariable activityId: Long,
+    ): ResponseEntity<ResponseWrapper<SatisfactionStatisticsResponse>> =
+        reviewStatisticsUseCase
+            .getSatisfactionStatistics(member?.memberId, activityId)
+            .map { it.toResponse() }
+            .let { SatisfactionStatisticsResponse(items = it) }
+            .let { ResponseWrapper.success(SuccessCode.GET_SATISFACTION_AVG_SCORES_SUCCESS, it) }
             .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewStatisticsController.kt
@@ -1,0 +1,26 @@
+package picklab.backend.review.entrypoint
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import picklab.backend.common.model.ResponseWrapper
+import picklab.backend.common.model.SuccessCode
+import picklab.backend.review.application.ReviewStatisticsUseCase
+import picklab.backend.review.entrypoint.response.JobRelevanceStatisticsResponse
+import picklab.backend.review.entrypoint.response.toResponse
+
+@RestController
+class ReviewStatisticsController(
+    private val reviewStatisticsUseCase: ReviewStatisticsUseCase,
+) : ReviewStatisticsApi {
+    @GetMapping("/v1/activities/{activityId}/reviews/statistics/job-relevance")
+    override fun getJobRelevanceStatistics(
+        @PathVariable activityId: Long,
+    ): ResponseEntity<ResponseWrapper<JobRelevanceStatisticsResponse>> =
+        reviewStatisticsUseCase
+            .getJobRelevanceStatistics(activityId)
+            .toResponse()
+            .let { ResponseWrapper.success(SuccessCode.GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS, it) }
+            .let { ResponseEntity.ok(it) }
+}

--- a/src/main/kotlin/picklab/backend/review/entrypoint/response/JobRelevanceStatisticsResponse.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/response/JobRelevanceStatisticsResponse.kt
@@ -1,0 +1,27 @@
+package picklab.backend.review.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+
+@Schema(description = "직무 연관성 통계 응답")
+data class JobRelevanceStatisticsResponse(
+    @Schema(description = "기획 직무 연관성 평균 점수")
+    val planningAvgScore: Double,
+    @Schema(description = "개발 직무 연관성 평균 점수")
+    val developmentAvgScore: Double,
+    @Schema(description = "마케팅 직무 연관성 평균 점수")
+    val marketingAvgScore: Double,
+    @Schema(description = "AI 직무 연관성 평균 점수")
+    val aiScore: Double,
+    @Schema(description = "디자인 직무 연관성 평균 점수")
+    val designAvgScore: Double,
+)
+
+fun JobRelevanceStatisticsItem.toResponse(): JobRelevanceStatisticsResponse =
+    JobRelevanceStatisticsResponse(
+        planningAvgScore = this.planningAvgScore,
+        developmentAvgScore = this.developmentAvgScore,
+        marketingAvgScore = this.marketingAvgScore,
+        aiScore = this.aiAvgScore,
+        designAvgScore = this.designAvgScore,
+    )

--- a/src/main/kotlin/picklab/backend/review/entrypoint/response/SatisfactionAvgScores.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/response/SatisfactionAvgScores.kt
@@ -1,0 +1,21 @@
+package picklab.backend.review.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+
+@Schema(description = "직무별 평균 점수 정보")
+data class SatisfactionAvgScores(
+    @Schema(description = "직무 그룹 코드 (null이면 전체를 의미)", example = "PLANNING", nullable = true)
+    val jobGroup: JobGroup?,
+    @Schema(description = "상세 직무 코드 (null이면 전체 혹은 그룹 전체를 의미)", example = "PM_PO", nullable = true)
+    val jobDetail: JobDetail?,
+    @Schema(description = "총 평점 평균")
+    val avgTotalScore: Double,
+    @Schema(description = "직무 경험 점수 평균")
+    val avgJobExperienceScore: Double,
+    @Schema(description = "활동 강도 점수 평균")
+    val avgActivityIntensityScore: Double,
+    @Schema(description = "혜택 및 복지 점수 평균")
+    val avgBenefitScore: Double,
+)

--- a/src/main/kotlin/picklab/backend/review/entrypoint/response/SatisfactionStatisticsResponse.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/response/SatisfactionStatisticsResponse.kt
@@ -1,0 +1,20 @@
+package picklab.backend.review.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.review.application.query.model.SatisfactionStatisticsItem
+
+@Schema(description = "활동 만족도 평가 통계 응답")
+data class SatisfactionStatisticsResponse(
+    @Schema(description = "전체 및 직무별 평균 점수 리스트")
+    val items: List<SatisfactionAvgScores>,
+)
+
+fun SatisfactionStatisticsItem.toResponse(): SatisfactionAvgScores =
+    SatisfactionAvgScores(
+        jobGroup = this.jobGroup,
+        jobDetail = this.jobDetail,
+        avgTotalScore = this.avgTotalScore,
+        avgJobExperienceScore = this.avgJobExperienceScore,
+        avgActivityIntensityScore = this.avgActivityIntensityScore,
+        avgBenefitScore = this.avgBenefitScore,
+    )

--- a/src/main/kotlin/picklab/backend/review/infrastructure/query/ReviewStatisticsQueryRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/review/infrastructure/query/ReviewStatisticsQueryRepositoryImpl.kt
@@ -1,10 +1,15 @@
 package picklab.backend.review.infrastructure.query
 
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
+import picklab.backend.job.domain.entity.QJobCategory.Companion.jobCategory
+import picklab.backend.job.domain.enums.JobDetail
 import picklab.backend.job.domain.enums.JobGroup
 import picklab.backend.review.application.query.ReviewStatisticsQueryRepository
 import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.application.query.model.QSatisfactionStatisticsItem
+import picklab.backend.review.application.query.model.SatisfactionStatisticsItem
 import picklab.backend.review.domain.entity.QReview.Companion.review
 import picklab.backend.review.domain.enums.ReviewApprovalStatus
 
@@ -40,5 +45,68 @@ class ReviewStatisticsQueryRepositoryImpl(
             aiAvgScore = scoreMap[JobGroup.AI] ?: 0.0,
             designAvgScore = scoreMap[JobGroup.DESIGN] ?: 0.0,
         )
+    }
+
+    override fun findSatisfactionStatistics(
+        activityId: Long,
+        jobCategoryIds: List<Long>,
+    ): List<SatisfactionStatisticsItem> {
+        val results = mutableListOf<SatisfactionStatisticsItem>()
+        val overall =
+            jpaQueryFactory
+                .select(
+                    QSatisfactionStatisticsItem(
+                        Expressions.nullExpression(JobGroup::class.java),
+                        Expressions.nullExpression(JobDetail::class.java),
+                        review.overallScore.avg(),
+                        review.infoScore.avg(),
+                        review.difficultyScore.avg(),
+                        review.benefitScore.avg(),
+                    ),
+                ).from(review)
+                .where(
+                    review.activity.id
+                        .eq(activityId)
+                        .and(review.reviewApprovalStatus.eq(ReviewApprovalStatus.APPROVED)),
+                ).fetchOne()
+
+        // 빈 데이터 Early Return
+        if (overall == null) {
+            return listOf(
+                SatisfactionStatisticsItem(
+                    jobGroup = null,
+                    jobDetail = null,
+                    avgTotalScore = 0.0,
+                    avgJobExperienceScore = 0.0,
+                    avgActivityIntensityScore = 0.0,
+                    avgBenefitScore = 0.0,
+                ),
+            )
+        }
+        results.add(overall)
+
+        if (jobCategoryIds.isNotEmpty()) {
+            val detailScores =
+                jpaQueryFactory
+                    .select(
+                        QSatisfactionStatisticsItem(
+                            jobCategory.jobGroup,
+                            jobCategory.jobDetail,
+                            review.overallScore.avg(),
+                            review.infoScore.avg(),
+                            review.difficultyScore.avg(),
+                            review.benefitScore.avg(),
+                        ),
+                    ).from(review)
+                    .join(review.jobCategory, jobCategory)
+                    .where(
+                        review.activity.id.eq(activityId),
+                        review.reviewApprovalStatus.eq(ReviewApprovalStatus.APPROVED),
+                        jobCategory.id.`in`(jobCategoryIds),
+                    ).groupBy(jobCategory.jobGroup, jobCategory.jobDetail)
+                    .fetch()
+            results.addAll(detailScores)
+        }
+        return results
     }
 }

--- a/src/main/kotlin/picklab/backend/review/infrastructure/query/ReviewStatisticsQueryRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/review/infrastructure/query/ReviewStatisticsQueryRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package picklab.backend.review.infrastructure.query
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import picklab.backend.job.domain.enums.JobGroup
+import picklab.backend.review.application.query.ReviewStatisticsQueryRepository
+import picklab.backend.review.application.query.model.JobRelevanceStatisticsItem
+import picklab.backend.review.domain.entity.QReview.Companion.review
+import picklab.backend.review.domain.enums.ReviewApprovalStatus
+
+@Repository
+class ReviewStatisticsQueryRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+) : ReviewStatisticsQueryRepository {
+    override fun findJobRelevanceStatistics(activityId: Long): JobRelevanceStatisticsItem {
+        val results =
+            jpaQueryFactory
+                .select(review.jobCategory.jobGroup, review.jobRelevanceScore.avg())
+                .from(review)
+                .where(
+                    review.activity.id
+                        .eq(activityId)
+                        .and(review.reviewApprovalStatus.eq(ReviewApprovalStatus.APPROVED)),
+                ).groupBy(review.jobCategory.jobGroup)
+                .fetch()
+
+        val scoreMap = mutableMapOf<JobGroup, Double>()
+
+        results.forEach { tuple ->
+            tuple.get(review.jobCategory.jobGroup)?.let { jobGroup ->
+                val avgScore = tuple.get(review.jobRelevanceScore.avg()) ?: 0.0
+                scoreMap[jobGroup] = avgScore
+            }
+        }
+
+        return JobRelevanceStatisticsItem(
+            planningAvgScore = scoreMap[JobGroup.PLANNING] ?: 0.0,
+            developmentAvgScore = scoreMap[JobGroup.DEVELOPMENT] ?: 0.0,
+            marketingAvgScore = scoreMap[JobGroup.MARKETING] ?: 0.0,
+            aiAvgScore = scoreMap[JobGroup.AI] ?: 0.0,
+            designAvgScore = scoreMap[JobGroup.DESIGN] ?: 0.0,
+        )
+    }
+}


### PR DESCRIPTION
## PR 설명
[✨feat: 활동별 직무 연관성 점수 평균 조회 기능 추가](https://github.com/picklab/picklab-be/commit/1ec8e2b0da354221bfe7755e5f4136293343504f)
- 비로그인 사용자도 API를 사용할 수 있도록 Security 설정을 수정하였습니다.
- 없는 데이터들은 0.0이 반환되도록 하였습니다.

[✨feat: 활동별 만족도 평가 평균 점수 조회 기능 추가](https://github.com/picklab/picklab-be/commit/2fdeeb648d9383d3b3940d7da4cbc5a3e94a0adc)
- 비로그인의 경우 전체만 응답하며,
로그인한 사용자의 요청인 경우 전체 + 사용자관심직무의 항목을 추가로 응답하도록 하였습니다.
- 전체 항목은 JobGroup, JobDetail 을 null 로 표현하였습니다.

## 리뷰 포인트
- 만족도 통계 조회 기능의 경우 label이 필요할까 고민했습니다.. 추후에 FE 분들과 의논할 때 요청 시 추가하는 쪽으로 하겠습니다.
- 응답 DTO로 변환의 책임을 누가 갖게 해야 할지, 의존성의 방향이 올바른지 고민을 많이해보고 현재 로직을 선택하였습니다. 그래서 application이 아닌 presentation 영역에서 처리하는 것이 좀 더 자연스럽고 의존성 방향도 올바르다 생각합니다. 혹시 이부분에 대해서 어떻게 생각하시는지 의견주시면 감사하겠습니다.💬