### PR TITLE
🐛 fix: enum 변환 실패 시 사용 가능한 값 목록 포함하여 응답

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/entrypoint/mapper/ActivitySearchConditionMapper.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/mapper/ActivitySearchConditionMapper.kt
@@ -1,30 +1,20 @@
 package picklab.backend.activity.entrypoint.mapper
 
 import picklab.backend.activity.application.model.ActivitySearchCondition
-import picklab.backend.activity.domain.enums.ActivityFieldType
-import picklab.backend.activity.domain.enums.ActivitySortType
-import picklab.backend.activity.domain.enums.ActivityType
-import picklab.backend.activity.domain.enums.DomainType
-import picklab.backend.activity.domain.enums.EducationCostType
-import picklab.backend.activity.domain.enums.EducationFormatType
-import picklab.backend.activity.domain.enums.LocationType
-import picklab.backend.activity.domain.enums.OrganizerType
-import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.entrypoint.request.ActivitySearchRequest
-import picklab.backend.job.domain.enums.JobDetail
 
 fun ActivitySearchRequest.toCondition(): ActivitySearchCondition =
     ActivitySearchCondition(
-        category = ActivityType.findByType(category),
-        jobTag = jobTag?.map(JobDetail::findByType),
-        organizer = organizer?.map(OrganizerType::findByType),
-        target = target?.map(ParticipantType::findByType),
-        field = field?.map(ActivityFieldType::findByType),
-        location = location?.map(LocationType::findByType),
-        format = format?.map(EducationFormatType::findByType),
-        costType = costType?.let { listOf(EducationCostType.findByType(it)) },
+        category = category,
+        jobTag = jobTag,
+        organizer = organizer,
+        target = target,
+        field = field,
+        location = location,
+        format = format,
+        costType = costType?.let { listOf(it) },
         award = award,
         duration = duration,
-        domain = domain?.map(DomainType::findByType),
-        sort = ActivitySortType.findByType(sort),
+        domain = domain,
+        sort = sort,
     )

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/request/ActivitySearchRequest.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/request/ActivitySearchRequest.kt
@@ -1,34 +1,40 @@
 package picklab.backend.activity.entrypoint.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.activity.domain.enums.ActivityFieldType
+import picklab.backend.activity.domain.enums.ActivitySortType
+import picklab.backend.activity.domain.enums.ActivityType
+import picklab.backend.activity.domain.enums.DomainType
+import picklab.backend.activity.domain.enums.EducationCostType
+import picklab.backend.activity.domain.enums.EducationFormatType
+import picklab.backend.activity.domain.enums.LocationType
+import picklab.backend.activity.domain.enums.OrganizerType
+import picklab.backend.activity.domain.enums.ParticipantType
+import picklab.backend.job.domain.enums.JobDetail
 
 data class ActivitySearchRequest(
-    @field:Schema(description = "활동 분류 (extracurricular, seminar, education, competition)")
-    val category: String,
+    @field:Schema(description = "활동 분류")
+    val category: ActivityType,
     @field:Schema(description = "관련 직무")
-    val jobTag: List<String>?,
+    val jobTag: List<JobDetail>?,
     @field:Schema(description = "주최 기관")
-    val organizer: List<String>?,
+    val organizer: List<OrganizerType>?,
     @field:Schema(description = "참여 대상")
-    val target: List<String>?,
+    val target: List<ParticipantType>?,
     @field:Schema(description = "활동 분야")
-    val field: List<String>?,
-    @field:Schema(
-        description =
-            "모임 지역(all, seoul_incheon, gyeonggi_gangwon, daejeon_sejong_chungnam, " +
-                "busan_daegu_gyeongsang, gwangju_jeolla, jeju, overseas)",
-    )
-    val location: List<String>?,
-    @field:Schema(description = "온/오프라인 여부(all, online, offline)")
-    val format: List<String>?,
-    @field:Schema(description = "비용 유형(free, paid, fully_government, partially_government)")
-    val costType: String?,
+    val field: List<ActivityFieldType>?,
+    @field:Schema(description = "모임 지역")
+    val location: List<LocationType>?,
+    @field:Schema(description = "온/오프라인 여부")
+    val format: List<EducationFormatType>?,
+    @field:Schema(description = "비용 유형")
+    val costType: EducationCostType?,
     @field:Schema(description = "최소 상금")
     val award: List<Long>?,
     @field:Schema(description = "최소 기간 (개월 단위, 최대 6)")
     val duration: List<Long>?,
-    @field:Schema(description = "도메인(saas, web, app, cloud, ai, ...)")
-    val domain: List<String>?,
-    @field:Schema(description = "정렬 기준(recent, deadline, remaining)")
-    val sort: String,
+    @field:Schema(description = "도메인")
+    val domain: List<DomainType>?,
+    @field:Schema(description = "정렬 기준")
+    val sort: ActivitySortType,
 )

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/request/GetMyBookmarkListRequest.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/request/GetMyBookmarkListRequest.kt
@@ -8,13 +8,13 @@ import picklab.backend.activity.domain.enums.RecruitmentStatus
 import picklab.backend.job.domain.enums.JobGroup
 
 data class GetMyBookmarkListRequest(
-    @field:Schema(description = "활동 분류 (extracurricular, seminar, education, competition)")
+    @field:Schema(description = "활동 분류")
     val activityTypes: List<ActivityType>? = null,
-    @field:Schema(description = "관련 직무(PLANNING, DESIGN, DEVELOPMENT, MARKETING, AI)")
+    @field:Schema(description = "관련 직무")
     val jobGroups: List<JobGroup>? = null,
-    @field:Schema(description = "모집 상태 (OPEN, CLOSED)")
+    @field:Schema(description = "모집 상태")
     val recruitmentStatus: RecruitmentStatus? = null,
-    @field:Schema(description = "정렬 기준 (RECENTLY_BOOKMARKED, LATEST, DEADLINE_ASC, DEADLINE_DESC)")
+    @field:Schema(description = "정렬 기준")
     val sortType: ActivityBookmarkSortType = ActivityBookmarkSortType.RECENTLY_BOOKMARKED,
     @field:Schema(description = "요청 페이지 (기본값 0)")
     val page: Int = 0,

--- a/src/main/kotlin/picklab/backend/auth/infrastructure/JwtExceptionFilter.kt
+++ b/src/main/kotlin/picklab/backend/auth/infrastructure/JwtExceptionFilter.kt
@@ -24,7 +24,7 @@ class JwtExceptionFilter(
         } catch (e: AuthException) {
             log.error("JWT Exception: {}", e.message)
             response.status = e.errorCode.status.value()
-            response.contentType = "application/json"
+            response.contentType = "application/json; charset=UTF-8"
             objectMapper.writeValue(response.writer, ErrorResponseWrapper.error(e.errorCode))
         }
     }

--- a/src/main/kotlin/picklab/backend/common/config/WebConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/WebConfig.kt
@@ -1,11 +1,17 @@
 package picklab.backend.common.config
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import picklab.backend.common.converter.CaseInsensitiveEnumConverterFactory
 
 @Configuration
 class WebConfig : WebMvcConfigurer {
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverterFactory(CaseInsensitiveEnumConverterFactory())
+    }
+
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
             .addMapping("/**")

--- a/src/main/kotlin/picklab/backend/common/converter/CaseInsensitiveEnumConverterFactory.kt
+++ b/src/main/kotlin/picklab/backend/common/converter/CaseInsensitiveEnumConverterFactory.kt
@@ -1,0 +1,17 @@
+package picklab.backend.common.converter
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.converter.ConverterFactory
+
+class CaseInsensitiveEnumConverterFactory : ConverterFactory<String, Enum<*>> {
+    override fun <T : Enum<*>> getConverter(targetType: Class<T>): Converter<String, T> = CaseInsensitiveEnumConverter(targetType)
+
+    private class CaseInsensitiveEnumConverter<T : Enum<*>>(
+        private val enumType: Class<T>,
+    ) : Converter<String, T> {
+        override fun convert(source: String): T =
+            enumType.enumConstants.firstOrNull {
+                it.name.equals(source, ignoreCase = true)
+            } ?: throw IllegalArgumentException()
+    }
+}

--- a/src/main/kotlin/picklab/backend/common/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/picklab/backend/common/handler/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package picklab.backend.common.handler
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import org.springframework.beans.ConversionNotSupportedException
 import org.springframework.beans.TypeMismatchException
 import org.springframework.http.ResponseEntity
@@ -98,16 +99,38 @@ class GlobalExceptionHandler {
     fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponseWrapper> {
         log.warn("[handleHttpMessageNotReadableException] ${e.message}", e)
 
+        if (e.cause is InvalidFormatException) {
+            val invalidFormatException = e.cause as InvalidFormatException
+
+            if (invalidFormatException.targetType.isEnum) {
+                val enumClass = invalidFormatException.targetType as Class<Enum<*>>
+                val enumConstants = enumClass.enumConstants.joinToString(", ") { it.name }
+                val rejectedValue = invalidFormatException.value
+
+                return ResponseEntity
+                    .status(ErrorCode.INVALID_INPUT_VALUE.status)
+                    .body(
+                        ErrorResponseWrapper.error(
+                            code = ErrorCode.INVALID_INPUT_VALUE,
+                            message = "존재하지 않는 값입니다: $rejectedValue (가능한 값: $enumConstants)",
+                            errors = emptyList(),
+                        ),
+                    )
+            }
+        }
+
         if (e.cause is JsonMappingException) {
             val mappingException = e.cause as JsonMappingException
 
             val errors =
                 mappingException.path
                     .mapNotNull { path ->
-                        ErrorField(
-                            field = path.fieldName,
-                            message = "${path.fieldName} 필드가 올바르지 않습니다.",
-                        )
+                        path.fieldName?.let { fieldName ->
+                            ErrorField(
+                                field = path.fieldName,
+                                message = "${path.fieldName} 필드가 올바르지 않습니다.",
+                            )
+                        }
                     }
 
             return ResponseEntity

--- a/src/main/kotlin/picklab/backend/common/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/picklab/backend/common/handler/GlobalExceptionHandler.kt
@@ -57,6 +57,24 @@ class GlobalExceptionHandler {
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponseWrapper> {
         log.warn("[handleMethodValidationException] ${e.message}", e)
 
+        for (fieldError in e.bindingResult.fieldErrors) {
+            if (fieldError.code == "typeMismatch") {
+                val field = e.bindingResult.getFieldType(fieldError.field)
+                if (field?.isEnum == true) {
+                    val enumConstants = field.enumConstants.joinToString(", ") { (it as Enum<*>).name }
+                    return ResponseEntity
+                        .status(ErrorCode.INVALID_INPUT_VALUE.status)
+                        .body(
+                            ErrorResponseWrapper.error(
+                                code = ErrorCode.INVALID_INPUT_VALUE,
+                                message = "존재하지 않는 값입니다: ${fieldError.rejectedValue} (가능한 값: $enumConstants)",
+                                errors = emptyList(),
+                            ),
+                        )
+                }
+            }
+        }
+
         val errors =
             e.bindingResult.fieldErrors.map { fieldError ->
                 ErrorField(

--- a/src/main/kotlin/picklab/backend/file/entrypoint/request/CreatePresignedUrlRequest.kt
+++ b/src/main/kotlin/picklab/backend/file/entrypoint/request/CreatePresignedUrlRequest.kt
@@ -10,7 +10,7 @@ data class CreatePresignedUrlRequest(
     @field:Schema(description = "업로드 할 파일 전체 이름(확장자 포함)", example = "example.jpg")
     val fileName: String,
     @field:NotBlank(message = "카테고리는 필수입니다.")
-    @field:Schema(description = "이미지가 업로드 되는 카테고리(PROFILE, ARCHIVE, REVIEW)", example = "PROFILE")
+    @field:Schema(description = "이미지가 업로드 되는 카테고리", example = "PROFILE")
     val category: FileCategory,
     @field:NotBlank(message = "파일 크기는 필수입니다.")
     @field:Schema(description = "업로드 할 파일 크기(Byte)", example = "2048")

--- a/src/main/kotlin/picklab/backend/job/application/JobUseCase.kt
+++ b/src/main/kotlin/picklab/backend/job/application/JobUseCase.kt
@@ -1,24 +1,13 @@
 package picklab.backend.job.application
 
 import org.springframework.stereotype.Component
-import picklab.backend.job.domain.entity.JobCategory
 import picklab.backend.job.domain.enums.JobDetail
 import picklab.backend.job.domain.enums.JobGroup
 import picklab.backend.job.domain.service.JobService
-import picklab.backend.member.entrypoint.request.JobCategoryDto
 
 @Component
 class JobUseCase(
     private val jobService: JobService,
 ) {
     fun findGrouped(): Map<JobGroup, List<JobDetail>> = jobService.groupByJobGroup()
-
-    fun findJobCategories(interestedJobCategories: List<JobCategoryDto>): List<JobCategory> {
-        val jobCategoryList =
-            interestedJobCategories.map {
-                JobGroup.valueOf(it.group) to JobDetail.valueOf(it.detail)
-            }
-
-        return jobService.findJobCategoriesByGroupAndDetail(jobCategoryList)
-    }
 }

--- a/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
+++ b/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
@@ -5,12 +5,10 @@ import picklab.backend.auth.domain.VerificationCodeService
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.file.application.FileManagementService
-import picklab.backend.job.domain.enums.JobDetail
-import picklab.backend.job.domain.enums.JobGroup
 import picklab.backend.job.domain.service.JobService
 import picklab.backend.member.domain.MemberService
 import picklab.backend.member.entrypoint.request.AdditionalInfoRequest
-import picklab.backend.member.entrypoint.request.JobCategoryDto
+import picklab.backend.member.entrypoint.request.MemberJobCategoryDto
 import picklab.backend.member.entrypoint.request.MemberWithdrawalRequest
 import picklab.backend.member.entrypoint.request.SendEmailRequest
 import picklab.backend.member.entrypoint.request.ToggleMemberNotificationRequest
@@ -59,14 +57,14 @@ class MemberUseCase(
 
     fun updateJobCategories(
         memberId: Long,
-        request: List<JobCategoryDto>,
+        request: List<MemberJobCategoryDto>,
     ) {
         if (request.size > 5) {
             throw BusinessException(ErrorCode.JOB_CATEGORY_LIMIT)
         }
         val member = memberService.clearInterestedJobCategories(memberId)
 
-        val jobCategoryList = request.map { JobGroup.valueOf(it.group) to JobDetail.valueOf(it.detail) }
+        val jobCategoryList = request.map { it.group to it.detail }
 
         val jobCategories = jobService.findJobCategoriesByGroupAndDetail(jobCategoryList)
 

--- a/src/main/kotlin/picklab/backend/member/entrypoint/request/AdditionalInfoRequest.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/request/AdditionalInfoRequest.kt
@@ -1,6 +1,5 @@
 package picklab.backend.member.entrypoint.request
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
@@ -18,31 +17,26 @@ data class AdditionalInfoRequest(
     @field:Schema(description = "회원 닉네임(필수)", example = "picklab멤버", maxLength = 20)
     val nickname: String,
     @field:NotBlank(message = "최종 학력은 필수 입력값입니다.")
-    @field:JsonProperty("education_level")
     @field:Schema(description = "최종 학력(필수)", example = "대학교(4년)")
     val educationLevel: String,
     @field:NotBlank(message = "학교명은 필수 입력값입니다.")
     @field:Schema(description = "학교명(필수)", example = "서울테스트학교")
     val school: String,
     @field:NotBlank(message = "전공은 필수 입력값입니다.")
-    @field:JsonProperty("graduation_status")
     @field:Schema(description = "졸업여부(필수)", example = "졸업")
     val graduationStatus: String,
-    @field:JsonProperty("employment_status")
     @field:Schema(description = "재직상태(선택)", example = "재직 중")
     val employmentStatus: String = "",
     @field:Schema(description = "회사명", example = "테스트기업")
     val company: String = "",
-    @field:JsonProperty("employment_type")
     @field:Schema(description = "고용 형태(선택)", example = "NONE")
     val employmentType: EmploymentType = EmploymentType.NONE,
     @field:NotEmpty(message = "관심 직군은 필수 입력값입니다.")
-    @field:JsonProperty("interested_job_categories")
     @field:Schema(description = "관심 직무 카테고리")
-    val interestedJobCategories: List<JobCategoryDto>,
+    val interestedJobCategories: List<MemberJobCategoryDto>,
 ) {
     fun toJobGroupDetailMap(): List<Pair<JobGroup, JobDetail>> =
         this.interestedJobCategories.map {
-            JobGroup.valueOf(it.group) to JobDetail.valueOf(it.detail)
+            it.group to it.detail
         }
 }

--- a/src/main/kotlin/picklab/backend/member/entrypoint/request/MemberJobCategoryDto.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/request/MemberJobCategoryDto.kt
@@ -2,12 +2,14 @@ package picklab.backend.member.entrypoint.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
 
-data class JobCategoryDto(
+data class MemberJobCategoryDto(
     @field:NotBlank(message = "직무 대분류는 필수 입력값입니다.")
     @field:Schema(description = "대분류", example = "PLANNING")
-    val group: String,
+    val group: JobGroup,
     @field:NotBlank(message = "상세 직무 옵션은 필수 입력값입니다.")
     @field:Schema(description = "상세 직무 옵션", example = "SERVICE_PLANNING")
-    val detail: String,
+    val detail: JobDetail,
 )

--- a/src/main/kotlin/picklab/backend/member/entrypoint/request/UpdateJobCategoriesRequest.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/request/UpdateJobCategoriesRequest.kt
@@ -8,5 +8,5 @@ data class UpdateJobCategoriesRequest(
     @field:NotEmpty(message = "관심 직무 카테고리는 필수 입력값입니다.")
     @field:JsonProperty("interested_job_categories")
     @field:Schema(description = "관심 직무 카테고리")
-    val interestedJobCategories: List<JobCategoryDto>,
+    val interestedJobCategories: List<MemberJobCategoryDto>,
 )

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewApi.kt
@@ -9,12 +9,12 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
-import picklab.backend.archive.entrypoint.request.ReviewCreateRequest
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.PageResponse
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
 import picklab.backend.review.entrypoint.request.MyReviewListRequest
+import picklab.backend.review.entrypoint.request.ReviewCreateRequest
 import picklab.backend.review.entrypoint.request.ReviewUpdateRequest
 import picklab.backend.review.entrypoint.response.ActivityReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewResponse

--- a/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/ReviewController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import picklab.backend.archive.entrypoint.request.ReviewCreateRequest
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.PageResponse
 import picklab.backend.common.model.ResponseWrapper
@@ -22,6 +21,7 @@ import picklab.backend.review.application.query.model.MyReviewListView
 import picklab.backend.review.entrypoint.mapper.toResponse
 import picklab.backend.review.entrypoint.request.ActivityReviewListRequest
 import picklab.backend.review.entrypoint.request.MyReviewListRequest
+import picklab.backend.review.entrypoint.request.ReviewCreateRequest
 import picklab.backend.review.entrypoint.request.ReviewUpdateRequest
 import picklab.backend.review.entrypoint.response.ActivityReviewResponse
 import picklab.backend.review.entrypoint.response.MyReviewResponse

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewCreateRequest.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewCreateRequest.kt
@@ -1,11 +1,10 @@
-package picklab.backend.archive.entrypoint.request
+package picklab.backend.review.entrypoint.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Size
 import picklab.backend.review.application.model.ReviewCreateCommand
-import picklab.backend.review.entrypoint.request.JobCategoryDto
 
 class ReviewCreateRequest(
     @field:Schema(description = "활동 ID")
@@ -45,7 +44,7 @@ class ReviewCreateRequest(
     @field:Schema(description = "리뷰 인증 자료 URL")
     val url: String? = null,
     @field:Schema(description = "직무 정보")
-    val jobCategory: JobCategoryDto,
+    val jobCategory: ReviewJobCategoryDto,
 ) {
     fun toCommand(memberId: Long): ReviewCreateCommand =
         ReviewCreateCommand(

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewJobCategoryDto.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewJobCategoryDto.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull
 import picklab.backend.job.domain.enums.JobDetail
 import picklab.backend.job.domain.enums.JobGroup
 
-data class JobCategoryDto(
+data class ReviewJobCategoryDto(
     @field:NotNull(message = "직무 대분류는 필수 입력값입니다.")
     @field:Schema(description = "관심 직무 대분류", example = "DEVELOPMENT")
     val jobGroup: JobGroup,

--- a/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewUpdateRequest.kt
+++ b/src/main/kotlin/picklab/backend/review/entrypoint/request/ReviewUpdateRequest.kt
@@ -44,7 +44,7 @@ data class ReviewUpdateRequest(
     @field:Schema(description = "리뷰 인증 자료 URL")
     val url: String? = null,
     @field:Schema(description = "직무 정보")
-    val jobCategory: JobCategoryDto,
+    val jobCategory: ReviewJobCategoryDto,
 ) {
     fun toCommand(
         id: Long,

--- a/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberServiceTest.kt
@@ -34,7 +34,7 @@ import picklab.backend.member.domain.repository.MemberVerificationRepository
 import picklab.backend.member.domain.repository.NotificationPreferenceRepository
 import picklab.backend.member.domain.repository.SocialLoginRepository
 import picklab.backend.member.entrypoint.request.AdditionalInfoRequest
-import picklab.backend.member.entrypoint.request.JobCategoryDto
+import picklab.backend.member.entrypoint.request.MemberJobCategoryDto
 import picklab.backend.member.entrypoint.request.MemberWithdrawalRequest
 import picklab.backend.member.entrypoint.request.UpdateInfoRequest
 import picklab.backend.member.entrypoint.request.UpdateProfileImageRequest
@@ -203,7 +203,7 @@ class MemberServiceTest : IntegrationTest() {
 
             val jobCategories =
                 listOf(
-                    JobCategoryDto("PLANNING", "SERVICE_PLANNING"),
+                    MemberJobCategoryDto(JobGroup.PLANNING, JobDetail.SERVICE_PLANNING),
                 )
 
             val additionalInfo =


### PR DESCRIPTION
## PR 설명

- [🐛 fix: enum 파라미터 변환 실패 시 사용 가능한 값 목록 포함하여 응답하도록 변경](https://github.com/picklab/picklab-be/commit/f47f04f292c674dfb3c801c5a049882460660c2a)
- [♻️ refactor: 직무 관련 DTO 및 직렬화 로직 네이밍 정리 및 타입 개선](https://github.com/picklab/picklab-be/commit/05b497d998633a6f7f8b9b20da796449287d34cc)
- [♻️ refactor: 직렬화 로직 개선 및 String 대신 enum을 통한 Validation 추가](https://github.com/picklab/picklab-be/commit/ae669cc45a45b36d0c5e623bd480dceb216a5b48)
- [🐛 fix: JWT 예외 필터의 응답 contentType을 UTF-8로 지정](https://github.com/picklab/picklab-be/commit/f1a303e226f05ff574434282fcabb9e8f9059d2c)
- [🐛 fix: request body의 enum 변환 실패 시 사용 가능한 값 목록 포함하여 응답하도록 변경](https://github.com/picklab/picklab-be/commit/3fd21a64f26297f1422d8029b2c7a2a122dd12a5)

## 작업 내용

- String → Enum 타입 변경
  - 타입 안전성 보장, Swagger 문서 자동 갱신
- Enum 변환 실패 시 친절한 에러 메시지
  - Query parameter와 Request body 모두 Enum 예외 클래스가 달라 둘 다 동일한 형태로 응답되도록 변경
- Query parameter의 경우에만 대소문자 무관 처리 컨버터 로직 추가
- JWT 관련 예외 응답의 UTF-8 인코딩 설정 (한글 깨짐 해결)
- Swagger 스키마 중복 문제 해결
  - `JobCategory` → `ReviewJobCategory`
  - `JobCategory` → `MemberJobCategory`
