### PR TITLE
✨ feat: 액세스 토큰 재발급 API 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/auth/application/TokenUseCase.kt
+++ b/src/main/kotlin/picklab/backend/auth/application/TokenUseCase.kt
@@ -1,0 +1,38 @@
+package picklab.backend.auth.application
+
+import org.springframework.stereotype.Component
+import picklab.backend.auth.domain.AuthToken
+import picklab.backend.auth.infrastructure.AccessTokenProvider
+import picklab.backend.auth.infrastructure.RefreshTokenProvider
+import picklab.backend.common.model.BusinessException
+import picklab.backend.common.model.ErrorCode
+import picklab.backend.member.domain.MemberService
+
+@Component
+class TokenUseCase(
+    private val refreshTokenProvider: RefreshTokenProvider,
+    private val memberService: MemberService,
+    private val accessTokenProvider: AccessTokenProvider,
+) {
+    fun refreshAccessToken(refreshToken: String): AuthToken {
+        if (!refreshTokenProvider.validateToken(refreshToken)) {
+            throw BusinessException(ErrorCode.INVALID_TOKEN)
+        }
+        val tokenType = refreshTokenProvider.getTokenType(refreshToken)
+        if (tokenType != "refresh") {
+            throw BusinessException(ErrorCode.INVALID_TOKEN)
+        }
+
+        val memberId = refreshTokenProvider.getSubject(refreshToken).toLong()
+        val member = memberService.findActiveMember(memberId)
+        if (member.refreshToken != refreshToken) {
+            throw BusinessException(ErrorCode.INVALID_TOKEN)
+        }
+        val newAccessToken = accessTokenProvider.generateToken(memberId)
+
+        return AuthToken(
+            accessToken = newAccessToken,
+            refreshToken = refreshToken,
+        )
+    }
+}

--- a/src/main/kotlin/picklab/backend/auth/entrypoint/AuthApi.kt
+++ b/src/main/kotlin/picklab/backend/auth/entrypoint/AuthApi.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestHeader
 import picklab.backend.auth.domain.AuthToken
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.member.domain.enums.SocialType
@@ -53,5 +54,29 @@ interface AuthApi {
     fun handleCallback(
         @Parameter(description = "소셜 로그인 제공자", required = true) provider: SocialType,
         @Parameter(description = "인증 코드", required = true) code: String,
+    ): ResponseEntity<ResponseWrapper<AuthToken>>
+
+    @Operation(
+        summary = "액세스 토큰 재발급",
+        description = """
+            리프레시 토큰을 이용하여 만료된 액세스 토큰을 재발급 받습니다.  
+            요청 헤더에 리프레시 토큰을 포함하여 전송하면, 토큰 검증 후 새로운 액세스 토큰을 발급합니다.  
+            Note: 스웨거 UI에서는 Authorization 헤더 입력이 제한됩니다.  
+            다른 도구(Postman, curl)를 통해 테스트를 권장합니다.  
+        """,
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "액세스 토큰 재발급 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "토큰이 유효하지 않거나 만료되었습니다.",
+            ),
+        ],
+    )
+    fun refreshAccessToken(
+        @Parameter(description = "리프레시 토큰", required = true)
+        @RequestHeader("Refresh-Token") authorization: String,
     ): ResponseEntity<ResponseWrapper<AuthToken>>
 }

--- a/src/main/kotlin/picklab/backend/auth/entrypoint/AuthController.kt
+++ b/src/main/kotlin/picklab/backend/auth/entrypoint/AuthController.kt
@@ -5,11 +5,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import picklab.backend.auth.application.AuthUseCase
 import picklab.backend.auth.application.OAuthProviderResolver
+import picklab.backend.auth.application.TokenUseCase
 import picklab.backend.auth.domain.AuthToken
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
@@ -21,6 +23,7 @@ import java.net.URI
 class AuthController(
     private val oAuthProviderResolver: OAuthProviderResolver,
     private val authUseCase: AuthUseCase,
+    private val tokenUseCase: TokenUseCase,
 ) : AuthApi {
     @GetMapping("/login/{provider}")
     override fun login(
@@ -44,5 +47,17 @@ class AuthController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(ResponseWrapper.success(SuccessCode.SOCIAL_LOGIN_SUCCESS, tokens))
+    }
+
+    @PostMapping("/refresh")
+    override fun refreshAccessToken(
+        @RequestHeader("Authorization") authorization: String,
+    ): ResponseEntity<ResponseWrapper<AuthToken>> {
+        val refreshToken = authorization.removePrefix("Bearer ").trim()
+        val tokens = tokenUseCase.refreshAccessToken(refreshToken)
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ResponseWrapper.success(SuccessCode.ACCESS_TOKEN_REFRESHED, tokens))
     }
 }

--- a/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
                 readOnlyUrl.forEach { path -> authorize(HttpMethod.GET, path, permitAll) }
                 authorize(HttpMethod.POST, "/v1/activities/{activityId}/view", permitAll)
                 authorize(HttpMethod.POST, "/v1/auth/callback/*", permitAll)
+                authorize(HttpMethod.POST, "/v1/auth/refresh", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -9,6 +9,7 @@ enum class SuccessCode(
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "소셜 로그인 성공"),
     JOB_DETAILS_RETRIEVED(HttpStatus.OK, "직무 상세 목록 조회에 성공했습니다."),
     SIGNUP_SUCCESS(HttpStatus.OK, "회원 가입에 성공했습니다."),
+    ACCESS_TOKEN_REFRESHED(HttpStatus.OK, "액세스 토큰 재발급 성공"),
 
     // Member 도메인 관련
     MEMBER_INFO_UPDATED(HttpStatus.OK, "회원 정보 수정에 성공했습니다."),

--- a/src/test/kotlin/picklab/backend/auth/TokenUseCaseTest.kt
+++ b/src/test/kotlin/picklab/backend/auth/TokenUseCaseTest.kt
@@ -1,0 +1,137 @@
+package picklab.backend.auth
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import picklab.backend.auth.application.TokenUseCase
+import picklab.backend.auth.infrastructure.AccessTokenProvider
+import picklab.backend.auth.infrastructure.RefreshTokenProvider
+import picklab.backend.common.model.BusinessException
+import picklab.backend.common.model.ErrorCode
+import picklab.backend.member.domain.MemberService
+import picklab.backend.member.domain.entity.Member
+
+@ExtendWith(MockKExtension::class)
+class TokenUseCaseTest {
+    @MockK
+    lateinit var memberService: MemberService
+
+    @MockK
+    lateinit var accessTokenProvider: AccessTokenProvider
+
+    @MockK
+    lateinit var refreshTokenProvider: RefreshTokenProvider
+
+    @InjectMockKs
+    lateinit var tokenUseCase: TokenUseCase
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰으로 액세스 토큰 재발급 성공")
+    fun refreshAccessToken_withValidToken_shouldReturnNewAccessToken() {
+        // given
+        val validRefreshToken = "valid.refresh.token"
+        val memberId = 1L
+        val newAccessToken = "new.access.token"
+        val mockMember =
+            mockk<Member> {
+                every { id } returns memberId
+                every { refreshToken } returns validRefreshToken
+            }
+
+        every { refreshTokenProvider.validateToken(validRefreshToken) } returns true
+        every { refreshTokenProvider.getTokenType(validRefreshToken) } returns "refresh"
+        every { refreshTokenProvider.getSubject(validRefreshToken) } returns memberId.toString()
+        every { memberService.findActiveMember(memberId) } returns mockMember
+        every { accessTokenProvider.generateToken(memberId) } returns newAccessToken
+
+        // when
+        val result = tokenUseCase.refreshAccessToken(validRefreshToken)
+
+        // then
+        assertThat(result.accessToken).isEqualTo(newAccessToken)
+        assertThat(result.refreshToken).isEqualTo(validRefreshToken)
+        verify(exactly = 1) { refreshTokenProvider.validateToken(validRefreshToken) }
+        verify(exactly = 1) { refreshTokenProvider.getTokenType(validRefreshToken) }
+        verify(exactly = 1) { memberService.findActiveMember(memberId) }
+        verify(exactly = 1) { accessTokenProvider.generateToken(memberId) }
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰으로 요청 시 INVALID_TOKEN 예외 발생")
+    fun refreshAccessToken_withInvalidToken_shouldThrowException() {
+        // given
+        val invalidToken = "invalid.token"
+        every { refreshTokenProvider.validateToken(invalidToken) } returns false
+
+        // when
+        val exception =
+            assertThrows<BusinessException> {
+                tokenUseCase.refreshAccessToken(invalidToken)
+            }
+
+        // then
+        assertThat(exception.errorCode).isEqualTo(ErrorCode.INVALID_TOKEN)
+        verify(exactly = 1) { refreshTokenProvider.validateToken(invalidToken) }
+        verify(exactly = 0) { memberService.findActiveMember(any()) }
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 타입으로 요청 시 INVALID_TOKEN 예외 발생")
+    fun refreshAccessToken_withAccessTokenType_shouldThrowException() {
+        // given
+        val accessToken = "access.token"
+        every { refreshTokenProvider.validateToken(accessToken) } returns true
+        every { refreshTokenProvider.getTokenType(accessToken) } returns "access"
+
+        // when
+        val exception =
+            assertThrows<BusinessException> {
+                tokenUseCase.refreshAccessToken(accessToken)
+            }
+
+        // then
+        assertThat(exception.errorCode).isEqualTo(ErrorCode.INVALID_TOKEN)
+        verify(exactly = 1) { refreshTokenProvider.validateToken(accessToken) }
+        verify(exactly = 1) { refreshTokenProvider.getTokenType(accessToken) }
+        verify(exactly = 0) { memberService.findActiveMember(any()) }
+    }
+
+    @Test
+    @DisplayName("DB 토큰과 불일치하는 리프레시 토큰으로 요청 시 INVALID_TOKEN 예외 발생")
+    fun refreshAccessToken_withMismatchedToken_shouldThrowException() {
+        // given
+        val requestToken = "request.token"
+        val dbToken = "db.token"
+        val memberId = 1L
+        val mockMember =
+            mockk<Member> {
+                every { id } returns memberId
+                every { refreshToken } returns dbToken
+            }
+
+        every { refreshTokenProvider.validateToken(requestToken) } returns true
+        every { refreshTokenProvider.getTokenType(requestToken) } returns "refresh"
+        every { refreshTokenProvider.getSubject(requestToken) } returns memberId.toString()
+        every { memberService.findActiveMember(memberId) } returns mockMember
+
+        // when
+        val exception =
+            assertThrows<BusinessException> {
+                tokenUseCase.refreshAccessToken(requestToken)
+            }
+
+        // then
+        assertThat(exception.errorCode).isEqualTo(ErrorCode.INVALID_TOKEN)
+        verify(exactly = 1) { refreshTokenProvider.validateToken(requestToken) }
+        verify(exactly = 1) { memberService.findActiveMember(memberId) }
+        verify(exactly = 0) { accessTokenProvider.generateToken(any()) }
+    }
+}


### PR DESCRIPTION
## PR 설명

- [✨ feat: 액세스 토큰 재발급 기능 추가](https://github.com/picklab/picklab-be/commit/b8639bff592f77cc6fa15fc071b3c03ca70a8e00) 
- [✅ test: 리프레시 토큰을 이용한 액세스 토큰 재발급 단위 테스트 추가](https://github.com/picklab/picklab-be/commit/8ae544e80bdca61dfaf9a9626b4df1e8fce95413)

## 참고

- 스웨거 UI에서는 Authorization 헤더 입력이 제한되어 포스트맨과 curl로 테스트를 마쳤습니다.