### PR TITLE
✨ fix: 활동 엔드포인트 인증 경로 매칭 수정

### DIFF
--- a/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.util.matcher.RegexRequestMatcher
 import picklab.backend.auth.infrastructure.JwtAccessDeniedHandler
 import picklab.backend.auth.infrastructure.JwtAuthenticationEntryPoint
 import picklab.backend.auth.infrastructure.JwtAuthenticationFilter
@@ -31,7 +32,6 @@ class SecurityConfig(
             "/swagger",
             "/v1/auth/login/*",
             "/v1/activities",
-            "/v1/activities/**",
             "/v1/search/autocomplete",
             "/v1/activities/*/reviews/statistics/**",
         )
@@ -48,6 +48,10 @@ class SecurityConfig(
             addFilterBefore<JwtAuthenticationFilter>(jwtExceptionFilter)
             authorizeHttpRequests {
                 authorize(HttpMethod.OPTIONS, "/**", permitAll)
+                authorize(
+                    RegexRequestMatcher("/v1/activities/\\d+.*", HttpMethod.GET.name()),
+                    permitAll,
+                )
                 readOnlyUrl.forEach { path -> authorize(HttpMethod.GET, path, permitAll) }
                 authorize(HttpMethod.POST, "/v1/activities/{activityId}/view", permitAll)
                 authorize(HttpMethod.POST, "/v1/auth/callback/*", permitAll)


### PR DESCRIPTION
## PR 설명

- [✨ fix: 활동 엔드포인트 인증 경로 매칭 수정](https://github.com/picklab/picklab-be/commit/008f7cd3319a23cb5b779ba8089c765fa21fa594)

## 작업 내용

비로그인 사용자의 활동 상세 페이지 접근을 허용하기 위해 설정한 `/v1/activities/**` 패턴이 인증이 필요한 다른 엔드포인트까지 허용하는 문제가 발생했습니다.


Spring Security의 PathPattern에서 `{activityId}` 패턴은 `/v1/activities/*`와 동일하게 동작하며, 모든 문자열(숫자뿐만 아니라 `recommendations`, `recently-viewed` 등)과 매칭됩니다.
문제가 되었던 설정은 다음과 같습니다.
```kotlin
"/v1/activities/**"  // 또는 "/v1/activities/{activityId}"
```

이로 인해 인증이 필요한 `/v1/activities/recommendations`, `/v1/activities/recently-viewed` 엔드포인트가 비인증 사용자에게 노출되었고, filter에서 인증은 허락하지만 인증객체는 nullable하지 않아, 500예외가 발생했습니다.


`/v1/activities/\d+.*`로 정규식을 사용하여 숫자로 시작되는 경로만 허용하도록 Security 설정을 변경하었습니다.


### 영향받는 API
**인증 필요 (정상 동작)**
- `[GET] /v1/activities/recently-viewed`
- `[GET] /v1/activities/recommendations`

**비로그인 허용 (정상 동작)**
- `[GET] /v1/activities/{activityId}` (숫자 ID)
- `[GET] /v1/activities/{activityId}/reviews`
- `[GET] /v1/activities/{activityId}/reviews/statistics/job-relevance`
- `[GET] /v1/activities/{activityId}/reviews/statistics/satisfaction`
