### PR TITLE
✨ feat: 회원 정보 조회 API 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/common/config/WebConfig.kt
+++ b/src/main/kotlin/picklab/backend/common/config/WebConfig.kt
@@ -1,5 +1,6 @@
 package picklab.backend.common.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.CorsRegistry
@@ -7,7 +8,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import picklab.backend.common.converter.CaseInsensitiveEnumConverterFactory
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(
+    @Value("\${cors.allowed-origins}")
+    private val allowedOrigins: String,
+) : WebMvcConfigurer {
     override fun addFormatters(registry: FormatterRegistry) {
         registry.addConverterFactory(CaseInsensitiveEnumConverterFactory())
     }
@@ -15,7 +19,7 @@ class WebConfig : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
             .addMapping("/**")
-            .allowedOrigins("http://localhost:3000")
+            .allowedOrigins(*allowedOrigins.split(",").toTypedArray())
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -20,6 +20,7 @@ enum class SuccessCode(
     VERIFY_EMAIL_CODE(HttpStatus.OK, "이메일 코드 인증에 성공했습니다."),
     UPDATE_EMAIL_AGREEMENT(HttpStatus.OK, "이메일 마케팅 수신 동의 정보 수정에 성공했습니다."),
     GET_MEMBER_SOCIAL_LOGINS(HttpStatus.OK, "소셜 로그인 연동 정보 조회에 성공했습니다."),
+    GET_MEMBER_ME(HttpStatus.OK, "내 정보 조회에 성공했습니다."),
     MEMBER_WITHDRAW(HttpStatus.OK, "회원 탈퇴에 성공했습니다."),
     SUBMIT_SURVEY(HttpStatus.OK, "탈퇴 설문 제출에 성공했습니다."),
     MEMBER_NOTIFICATION_UPDATED(HttpStatus.OK, "알림 변경에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
+++ b/src/main/kotlin/picklab/backend/member/application/MemberUseCase.kt
@@ -1,11 +1,14 @@
 package picklab.backend.member.application
 
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import picklab.backend.auth.domain.VerificationCodeService
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.file.application.FileManagementService
 import picklab.backend.job.domain.service.JobService
+import picklab.backend.member.application.mapper.toMemberMeResult
+import picklab.backend.member.application.model.MemberMeResult
 import picklab.backend.member.domain.MemberService
 import picklab.backend.member.entrypoint.request.AdditionalInfoRequest
 import picklab.backend.member.entrypoint.request.MemberJobCategoryDto
@@ -126,6 +129,13 @@ class MemberUseCase(
     }
 
     fun getSocialLogins(memberId: Long) = memberService.getSocialLogins(memberId)
+
+    @Transactional(readOnly = true)
+    fun getMemberMe(memberId: Long): MemberMeResult {
+        val member = memberService.findActiveMember(memberId)
+        val interestedJobCategories = memberService.findInterestedJobCategories(memberId)
+        return member.toMemberMeResult(interestedJobCategories)
+    }
 
     fun withdrawMember(memberId: Long) {
         memberService.withdrawMember(memberId)

--- a/src/main/kotlin/picklab/backend/member/application/mapper/MemberMeMapper.kt
+++ b/src/main/kotlin/picklab/backend/member/application/mapper/MemberMeMapper.kt
@@ -1,0 +1,17 @@
+package picklab.backend.member.application.mapper
+
+import picklab.backend.member.application.model.MemberMeResult
+import picklab.backend.member.domain.entity.InterestedJobCategory
+import picklab.backend.member.domain.entity.Member
+
+fun Member.toMemberMeResult(interestedJobCategories: List<InterestedJobCategory>): MemberMeResult =
+    MemberMeResult(
+        name = this.name,
+        nickname = this.nickname,
+        educationLevel = this.educationLevel,
+        birthDate = this.birthDate,
+        selectedInterestedJobs = interestedJobCategories.mapNotNull { it.jobCategory.jobDetail },
+        jobFields = interestedJobCategories.map { it.jobCategory.jobGroup }.distinct(),
+        employmentStatus = this.employmentStatus,
+        company = this.company,
+    )

--- a/src/main/kotlin/picklab/backend/member/application/model/MemberMeResult.kt
+++ b/src/main/kotlin/picklab/backend/member/application/model/MemberMeResult.kt
@@ -1,0 +1,16 @@
+package picklab.backend.member.application.model
+
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import java.time.LocalDate
+
+data class MemberMeResult(
+    val name: String,
+    val nickname: String,
+    val educationLevel: String,
+    val birthDate: LocalDate?,
+    val selectedInterestedJobs: List<JobDetail>,
+    val jobFields: List<JobGroup>,
+    val employmentStatus: String,
+    val company: String,
+)

--- a/src/main/kotlin/picklab/backend/member/domain/MemberService.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/MemberService.kt
@@ -236,6 +236,9 @@ class MemberService(
         )
     }
 
+    fun findInterestedJobCategories(memberId: Long): List<InterestedJobCategory> =
+        interestedJobCategoryRepository.findAllByMemberIdWithJobCategory(memberId)
+
     @Transactional
     fun withdrawMember(memberId: Long) {
         val member = findActiveMember(memberId)

--- a/src/main/kotlin/picklab/backend/member/domain/repository/InterestedJobCategoryRepository.kt
+++ b/src/main/kotlin/picklab/backend/member/domain/repository/InterestedJobCategoryRepository.kt
@@ -9,6 +9,19 @@ import picklab.backend.member.domain.entity.Member
 interface InterestedJobCategoryRepository : JpaRepository<InterestedJobCategory, Long> {
     fun deleteAllByMember(member: Member)
 
+    @Query(
+        """
+        SELECT ijc
+        FROM InterestedJobCategory ijc
+        JOIN FETCH ijc.jobCategory jc
+        WHERE ijc.member.id = :memberId
+        ORDER BY ijc.id
+        """,
+    )
+    fun findAllByMemberIdWithJobCategory(
+        @Param("memberId") memberId: Long,
+    ): List<InterestedJobCategory>
+
     @Query("SELECT jc.id FROM InterestedJobCategory ijc JOIN ijc.jobCategory jc WHERE ijc.member.id = :memberId")
     fun findJobCategoryIdsByMemberId(
         @Param("memberId") memberId: Long,

--- a/src/main/kotlin/picklab/backend/member/entrypoint/MemberApi.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/MemberApi.kt
@@ -20,6 +20,7 @@ import picklab.backend.member.entrypoint.request.UpdateInfoRequest
 import picklab.backend.member.entrypoint.request.UpdateJobCategoriesRequest
 import picklab.backend.member.entrypoint.request.UpdateProfileImageRequest
 import picklab.backend.member.entrypoint.request.VerifyEmailCodeRequest
+import picklab.backend.member.entrypoint.response.GetMemberMeResponse
 import picklab.backend.member.entrypoint.response.GetSocialLoginsResponse
 
 @Tag(name = "회원 API", description = "회원 관련 작업을 하는 API")
@@ -176,6 +177,21 @@ interface MemberApi {
     fun getSocialLogins(
         @AuthenticationPrincipal member: MemberPrincipal,
     ): ResponseEntity<ResponseWrapper<GetSocialLoginsResponse>>
+
+    @Operation(
+        summary = "내 정보 조회",
+        description = "로그인한 사용자의 기본 프로필, 관심 직무, 재직 상태를 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "내 정보 조회에 성공했습니다."),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다."),
+            ApiResponse(responseCode = "500", description = "서버 오류입니다."),
+        ],
+    )
+    fun getMyInfo(
+        @AuthenticationPrincipal member: MemberPrincipal,
+    ): ResponseEntity<ResponseWrapper<GetMemberMeResponse>>
 
     @Operation(
         summary = "회원 탈퇴",

--- a/src/main/kotlin/picklab/backend/member/entrypoint/MemberController.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/MemberController.kt
@@ -16,6 +16,7 @@ import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.member.application.MemberUseCase
+import picklab.backend.member.entrypoint.mapper.toResponse
 import picklab.backend.member.entrypoint.request.AdditionalInfoRequest
 import picklab.backend.member.entrypoint.request.MemberWithdrawalRequest
 import picklab.backend.member.entrypoint.request.SendEmailRequest
@@ -26,6 +27,7 @@ import picklab.backend.member.entrypoint.request.UpdateInfoRequest
 import picklab.backend.member.entrypoint.request.UpdateJobCategoriesRequest
 import picklab.backend.member.entrypoint.request.UpdateProfileImageRequest
 import picklab.backend.member.entrypoint.request.VerifyEmailCodeRequest
+import picklab.backend.member.entrypoint.response.GetMemberMeResponse
 import picklab.backend.member.entrypoint.response.GetSocialLoginsResponse
 
 @RestController
@@ -151,17 +153,27 @@ class MemberController(
     override fun getSocialLogins(
         @AuthenticationPrincipal member: MemberPrincipal,
     ): ResponseEntity<ResponseWrapper<GetSocialLoginsResponse>> {
-        memberUseCase.getSocialLogins(member.memberId)
+        val response = memberUseCase.getSocialLogins(member.memberId)
 
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
                 ResponseWrapper.success(
                     SuccessCode.GET_MEMBER_SOCIAL_LOGINS,
-                    memberUseCase.getSocialLogins(member.memberId),
+                    response,
                 ),
             )
     }
+
+    @GetMapping("/me")
+    override fun getMyInfo(
+        @AuthenticationPrincipal member: MemberPrincipal,
+    ): ResponseEntity<ResponseWrapper<GetMemberMeResponse>> =
+        memberUseCase
+            .getMemberMe(member.memberId)
+            .toResponse()
+            .let { ResponseWrapper.success(SuccessCode.GET_MEMBER_ME, it) }
+            .let { ResponseEntity.ok(it) }
 
     @DeleteMapping("")
     override fun withdrawMember(

--- a/src/main/kotlin/picklab/backend/member/entrypoint/mapper/MemberMeMapper.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/mapper/MemberMeMapper.kt
@@ -1,0 +1,20 @@
+package picklab.backend.member.entrypoint.mapper
+
+import picklab.backend.member.application.model.MemberMeResult
+import picklab.backend.member.entrypoint.response.EmploymentInfoResponse
+import picklab.backend.member.entrypoint.response.GetMemberMeResponse
+
+fun MemberMeResult.toResponse(): GetMemberMeResponse =
+    GetMemberMeResponse(
+        name = this.name,
+        nickname = this.nickname,
+        educationLevel = this.educationLevel,
+        birthDate = this.birthDate,
+        selectedInterestedJobs = this.selectedInterestedJobs,
+        jobFields = this.jobFields,
+        employment =
+            EmploymentInfoResponse(
+                employmentStatus = this.employmentStatus,
+                company = this.company,
+            ),
+    )

--- a/src/main/kotlin/picklab/backend/member/entrypoint/response/GetMemberMeResponse.kt
+++ b/src/main/kotlin/picklab/backend/member/entrypoint/response/GetMemberMeResponse.kt
@@ -1,0 +1,30 @@
+package picklab.backend.member.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import java.time.LocalDate
+
+data class GetMemberMeResponse(
+    @field:Schema(description = "이름")
+    val name: String,
+    @field:Schema(description = "닉네임")
+    val nickname: String,
+    @field:Schema(description = "최종 학력")
+    val educationLevel: String,
+    @field:Schema(description = "생년월일")
+    val birthDate: LocalDate?,
+    @field:Schema(description = "선택한 관심 직무")
+    val selectedInterestedJobs: List<JobDetail>,
+    @field:Schema(description = "직무 분야")
+    val jobFields: List<JobGroup>,
+    @field:Schema(description = "재직 상태")
+    val employment: EmploymentInfoResponse,
+)
+
+data class EmploymentInfoResponse(
+    @field:Schema(description = "재직 상태")
+    val employmentStatus: String,
+    @field:Schema(description = "회사")
+    val company: String,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,6 +97,8 @@ oci:
   storage:
     bucket-name: ${OCI_BUCKET_NAME}
 
+cors:
+  allowed-origins: http://localhost:3000, https://picklab-fe.vercel.app
 ---
 spring:
   config:

--- a/src/test/kotlin/picklab/backend/member/entrypoint/MemberMeControllerTest.kt
+++ b/src/test/kotlin/picklab/backend/member/entrypoint/MemberMeControllerTest.kt
@@ -1,0 +1,61 @@
+package picklab.backend.member.entrypoint
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import picklab.backend.common.model.SuccessCode
+import picklab.backend.helper.WithMockUser
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import picklab.backend.member.application.MemberUseCase
+import picklab.backend.member.application.model.MemberMeResult
+import java.time.LocalDate
+
+@WebMvcTest(MemberController::class)
+class MemberMeControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var memberUseCase: MemberUseCase
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /v1/members/me는 필요한 필드를 한 번에 반환한다")
+    fun getMemberMe() {
+        given(memberUseCase.getMemberMe(1L)).willReturn(
+            MemberMeResult(
+                name = "hong",
+                nickname = "picklab_member",
+                educationLevel = "대학교(4년)",
+                birthDate = LocalDate.of(1998, 3, 1),
+                selectedInterestedJobs = listOf(JobDetail.BACKEND, JobDetail.DEVOPS),
+                jobFields = listOf(JobGroup.DEVELOPMENT),
+                employmentStatus = "재직 중",
+                company = "Picklab",
+            ),
+        )
+
+        mockMvc
+            .get("/v1/members/me") {
+                with(csrf())
+            }.andExpect { status { isOk() } }
+            .andExpect { jsonPath("$.code") { value(SuccessCode.GET_MEMBER_ME.status.value()) } }
+            .andExpect { jsonPath("$.message") { value(SuccessCode.GET_MEMBER_ME.message) } }
+            .andExpect { jsonPath("$.data.name") { value("hong") } }
+            .andExpect { jsonPath("$.data.nickname") { value("picklab_member") } }
+            .andExpect { jsonPath("$.data.education_level") { value("대학교(4년)") } }
+            .andExpect { jsonPath("$.data.birth_date") { value("1998-03-01") } }
+            .andExpect { jsonPath("$.data.selected_interested_jobs[0]") { value("BACKEND") } }
+            .andExpect { jsonPath("$.data.selected_interested_jobs[1]") { value("DEVOPS") } }
+            .andExpect { jsonPath("$.data.job_fields[0]") { value("DEVELOPMENT") } }
+            .andExpect { jsonPath("$.data.employment.employment_status") { value("재직 중") } }
+            .andExpect { jsonPath("$.data.employment.company") { value("Picklab") } }
+    }
+}

--- a/src/test/kotlin/picklab/backend/member/service/MemberMeServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/member/service/MemberMeServiceTest.kt
@@ -1,0 +1,87 @@
+package picklab.backend.member.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import picklab.backend.job.domain.JobCategoryRepository
+import picklab.backend.job.domain.entity.JobCategory
+import picklab.backend.job.domain.enums.JobDetail
+import picklab.backend.job.domain.enums.JobGroup
+import picklab.backend.member.application.MemberUseCase
+import picklab.backend.member.domain.entity.InterestedJobCategory
+import picklab.backend.member.domain.entity.Member
+import picklab.backend.member.domain.repository.InterestedJobCategoryRepository
+import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.template.IntegrationTest
+import java.time.LocalDate
+
+class MemberMeServiceTest : IntegrationTest() {
+    @Autowired
+    lateinit var memberUseCase: MemberUseCase
+
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    lateinit var interestedJobCategoryRepository: InterestedJobCategoryRepository
+
+    @Autowired
+    lateinit var jobCategoryRepository: JobCategoryRepository
+
+    @BeforeEach
+    fun setUp() {
+        cleanUp.all()
+    }
+
+    @Test
+    @DisplayName("getMemberMe는 요청한 회원 필드와 직무 데이터를 반환한다")
+    fun getMemberMe() {
+        val member =
+            memberRepository.save(
+                Member(
+                    name = "hong",
+                    email = "test@example.com",
+                    nickname = "picklab_member",
+                    educationLevel = "대학교(4년)",
+                    birthDate = LocalDate.of(1998, 3, 1),
+                    employmentStatus = "재직 중",
+                    company = "Picklab",
+                ),
+            )
+
+        val backend =
+            jobCategoryRepository.save(
+                JobCategory(
+                    jobGroup = JobGroup.DEVELOPMENT,
+                    jobDetail = JobDetail.BACKEND,
+                ),
+            )
+        val devops =
+            jobCategoryRepository.save(
+                JobCategory(
+                    jobGroup = JobGroup.DEVELOPMENT,
+                    jobDetail = JobDetail.DEVOPS,
+                ),
+            )
+
+        interestedJobCategoryRepository.saveAll(
+            listOf(
+                InterestedJobCategory(member, backend),
+                InterestedJobCategory(member, devops),
+            ),
+        )
+
+        val result = memberUseCase.getMemberMe(member.id)
+
+        assertThat(result.name).isEqualTo("hong")
+        assertThat(result.nickname).isEqualTo("picklab_member")
+        assertThat(result.educationLevel).isEqualTo("대학교(4년)")
+        assertThat(result.birthDate).isEqualTo(LocalDate.of(1998, 3, 1))
+        assertThat(result.selectedInterestedJobs).containsExactly(JobDetail.BACKEND, JobDetail.DEVOPS)
+        assertThat(result.jobFields).containsExactly(JobGroup.DEVELOPMENT)
+        assertThat(result.employmentStatus).isEqualTo("재직 중")
+        assertThat(result.company).isEqualTo("Picklab")
+    }
+}


### PR DESCRIPTION
## PR 설명
- [🔧 config: picklab-fe.vercel.app 도메인 허용 추가 및 yml에서 설정으로 변경](https://github.com/picklab/picklab-be/commit/df8b9a0a14aabf05a2cd4685fb0dd70b560aa3b6)
- [✨ feat: 회원 정보 조회 /me API 추가](https://github.com/picklab/picklab-be/commit/34d5850890d95a09c04abfcbda78b0c284c2b3a9)

## 작업 내용
  - GET `/v1/members/me` 엔드포인트 추가
  - 로그인한 사용자의 프로필, 관심 직무, 재직 상태 반환
  - `picklab-fe.vercel.app` 도메인 CORS 허용 추가
