### PR TITLE
✨ feat: 활동 그룹 API 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityUseCase.kt
@@ -16,11 +16,11 @@ import picklab.backend.activity.application.model.PopularActivitiesCondition
 import picklab.backend.activity.application.model.RecentlyViewedActivitiesCondition
 import picklab.backend.activity.application.model.RecommendActivitiesCondition
 import picklab.backend.activity.domain.service.ActivityBookmarkService
-import picklab.backend.activity.domain.service.ActivityGroupService
 import picklab.backend.activity.domain.service.ActivityJobCategoryService
 import picklab.backend.activity.domain.service.ActivityService
 import picklab.backend.activity.domain.service.ActivityUploadFileService
 import picklab.backend.activity.entrypoint.response.GetActivityDetailResponse
+import picklab.backend.activitygroup.domain.service.ActivityGroupService
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.job.domain.service.JobService

--- a/src/main/kotlin/picklab/backend/activity/application/mapper/ActivityCreateMapper.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/mapper/ActivityCreateMapper.kt
@@ -6,13 +6,13 @@ import picklab.backend.activity.application.model.EducationActivityCreateCommand
 import picklab.backend.activity.application.model.ExternalActivityCreateCommand
 import picklab.backend.activity.application.model.SeminarActivityCreateCommand
 import picklab.backend.activity.domain.entity.Activity
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ActivityJobCategory
 import picklab.backend.activity.domain.entity.ActivityUploadFile
 import picklab.backend.activity.domain.entity.CompetitionActivity
 import picklab.backend.activity.domain.entity.EducationActivity
 import picklab.backend.activity.domain.entity.ExternalActivity
 import picklab.backend.activity.domain.entity.SeminarActivity
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import picklab.backend.job.domain.entity.JobCategory
 
 fun ActivityCreateCommand.toEntity(activityGroup: ActivityGroup): Activity =

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/Activity.kt
@@ -18,6 +18,7 @@ import org.hibernate.annotations.SQLRestriction
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import picklab.backend.common.model.SoftDeleteEntity
 import java.time.LocalDate
 

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/CompetitionActivity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/CompetitionActivity.kt
@@ -10,6 +10,7 @@ import picklab.backend.activity.domain.enums.DomainType
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import java.time.LocalDate
 
 @Entity

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/EducationActivity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/EducationActivity.kt
@@ -12,6 +12,7 @@ import picklab.backend.activity.domain.enums.LocationType
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import java.time.LocalDate
 
 @Entity

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/ExternalActivity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/ExternalActivity.kt
@@ -11,6 +11,7 @@ import picklab.backend.activity.domain.enums.LocationType
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import java.time.LocalDate
 
 @Entity

--- a/src/main/kotlin/picklab/backend/activity/domain/entity/SeminarActivity.kt
+++ b/src/main/kotlin/picklab/backend/activity/domain/entity/SeminarActivity.kt
@@ -10,6 +10,7 @@ import picklab.backend.activity.domain.enums.LocationType
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import java.time.LocalDate
 
 @Entity

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityApi.kt
@@ -27,14 +27,14 @@ interface ActivityApi {
         summary = "활동 생성",
         description =
             "activity DDL 기준으로 활동을 생성합니다.\n\n" +
-                "공통 필수값은 activityType, activityGroupId, title, organizer, targetAudience, " +
+                "공통 필수값은 activity_type, activity_group_id, title, organizer, target_audience, " +
                 "recruitmentStartDate, recruitmentEndDate, startDate, endDate, status, duration 입니다.\n\n" +
-                "공통 선택값은 activityHomepageUrl, activityApplicationUrl, activityThumbnailUrl, " +
-                "description, benefit, jobCategories, uploadFiles 입니다.\n\n" +
+                "공통 선택값은 activity_homepage_url, activity_application_url, activity_thumbnail_url, " +
+                "description, benefit, job_categories, upload_files 입니다.\n\n" +
                 "타입별 필수값:\n" +
-                "- EXTRACURRICULAR: location, activityField\n" +
+                "- EXTRACURRICULAR: location, activity_field\n" +
                 "- SEMINAR: location\n" +
-                "- EDUCATION: location, cost, costType, educationFormat\n" +
+                "- EDUCATION: location, cost, cost_type, education_format\n" +
                 "- COMPETITION: domain, cost",
         responses = [
             ApiResponse(responseCode = "200", description = "활동 생성에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/request/ActivityCreateRequest.kt
@@ -32,7 +32,7 @@ import java.time.LocalDate
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "activityType",
+    property = "activity_type",
     visible = true,
 )
 @JsonSubTypes(
@@ -42,8 +42,8 @@ import java.time.LocalDate
     JsonSubTypes.Type(value = CompetitionActivityCreateRequest::class, name = "COMPETITION"),
 )
 @Schema(
-    description = "활동 생성 요청. activityType 값에 따라 타입별 필드를 입력합니다.",
-    discriminatorProperty = "activityType",
+    description = "활동 생성 요청. activity_type 값에 따라 타입별 필드를 입력합니다.",
+    discriminatorProperty = "activity_type",
     oneOf = [
         ExternalActivityCreateRequest::class,
         SeminarActivityCreateRequest::class,

--- a/src/main/kotlin/picklab/backend/activitygroup/application/ActivityGroupQueryUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/ActivityGroupQueryUseCase.kt
@@ -1,0 +1,12 @@
+package picklab.backend.activitygroup.application
+
+import org.springframework.stereotype.Component
+import picklab.backend.activitygroup.application.query.model.ActivityGroupView
+import picklab.backend.activitygroup.application.service.ActivityGroupQueryService
+
+@Component
+class ActivityGroupQueryUseCase(
+    private val activityGroupQueryService: ActivityGroupQueryService,
+) {
+    fun getActivityGroups(): List<ActivityGroupView> = activityGroupQueryService.findAll()
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/application/ActivityGroupUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/ActivityGroupUseCase.kt
@@ -1,0 +1,17 @@
+package picklab.backend.activitygroup.application
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.activitygroup.application.mapper.toEntity
+import picklab.backend.activitygroup.application.model.ActivityGroupCreateCommand
+import picklab.backend.activitygroup.domain.service.ActivityGroupService
+
+@Component
+class ActivityGroupUseCase(
+    private val activityGroupService: ActivityGroupService,
+) {
+    @Transactional
+    fun createActivityGroup(command: ActivityGroupCreateCommand) {
+        activityGroupService.save(command.toEntity())
+    }
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/application/mapper/ActivityGroupMapper.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/mapper/ActivityGroupMapper.kt
@@ -1,0 +1,10 @@
+package picklab.backend.activitygroup.application.mapper
+
+import picklab.backend.activitygroup.application.model.ActivityGroupCreateCommand
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+
+fun ActivityGroupCreateCommand.toEntity(): ActivityGroup =
+    ActivityGroup(
+        name = name,
+        description = description,
+    )

--- a/src/main/kotlin/picklab/backend/activitygroup/application/mapper/ActivityGroupMapper.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/mapper/ActivityGroupMapper.kt
@@ -1,10 +1,18 @@
 package picklab.backend.activitygroup.application.mapper
 
 import picklab.backend.activitygroup.application.model.ActivityGroupCreateCommand
+import picklab.backend.activitygroup.application.query.model.ActivityGroupView
 import picklab.backend.activitygroup.domain.entity.ActivityGroup
 
 fun ActivityGroupCreateCommand.toEntity(): ActivityGroup =
     ActivityGroup(
+        name = name,
+        description = description,
+    )
+
+fun ActivityGroup.toView(): ActivityGroupView =
+    ActivityGroupView(
+        id = id,
         name = name,
         description = description,
     )

--- a/src/main/kotlin/picklab/backend/activitygroup/application/model/ActivityGroupCreateCommand.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/model/ActivityGroupCreateCommand.kt
@@ -1,0 +1,6 @@
+package picklab.backend.activitygroup.application.model
+
+data class ActivityGroupCreateCommand(
+    val name: String,
+    val description: String,
+)

--- a/src/main/kotlin/picklab/backend/activitygroup/application/query/model/ActivityGroupView.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/query/model/ActivityGroupView.kt
@@ -1,0 +1,7 @@
+package picklab.backend.activitygroup.application.query.model
+
+data class ActivityGroupView(
+    val id: Long,
+    val name: String,
+    val description: String,
+)

--- a/src/main/kotlin/picklab/backend/activitygroup/application/service/ActivityGroupQueryService.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/application/service/ActivityGroupQueryService.kt
@@ -1,0 +1,19 @@
+package picklab.backend.activitygroup.application.service
+
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.activitygroup.application.mapper.toView
+import picklab.backend.activitygroup.application.query.model.ActivityGroupView
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
+
+@Service
+class ActivityGroupQueryService(
+    private val activityGroupRepository: ActivityGroupRepository,
+) {
+    @Transactional(readOnly = true)
+    fun findAll(): List<ActivityGroupView> =
+        activityGroupRepository
+            .findAll(Sort.by(Sort.Direction.ASC, "id"))
+            .map { it.toView() }
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/domain/entity/ActivityGroup.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/domain/entity/ActivityGroup.kt
@@ -1,4 +1,4 @@
-package picklab.backend.activity.domain.entity
+package picklab.backend.activitygroup.domain.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/src/main/kotlin/picklab/backend/activitygroup/domain/repository/ActivityGroupRepository.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/domain/repository/ActivityGroupRepository.kt
@@ -1,6 +1,6 @@
-package picklab.backend.activity.domain.repository
+package picklab.backend.activitygroup.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import picklab.backend.activity.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 
 interface ActivityGroupRepository : JpaRepository<ActivityGroup, Long>

--- a/src/main/kotlin/picklab/backend/activitygroup/domain/service/ActivityGroupService.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/domain/service/ActivityGroupService.kt
@@ -1,8 +1,9 @@
-package picklab.backend.activity.domain.service
+package picklab.backend.activitygroup.domain.service
 
 import org.springframework.stereotype.Service
-import picklab.backend.activity.domain.entity.ActivityGroup
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
+import org.springframework.transaction.annotation.Transactional
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.common.model.BusinessException
 import picklab.backend.common.model.ErrorCode
 
@@ -10,6 +11,10 @@ import picklab.backend.common.model.ErrorCode
 class ActivityGroupService(
     private val activityGroupRepository: ActivityGroupRepository,
 ) {
+    @Transactional
+    fun save(entity: ActivityGroup): ActivityGroup = activityGroupRepository.save(entity)
+
+    @Transactional(readOnly = true)
     fun mustFindById(id: Long): ActivityGroup =
         activityGroupRepository
             .findById(id)

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupApi.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupApi.kt
@@ -1,0 +1,24 @@
+package picklab.backend.activitygroup.entrypoint
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.common.model.ResponseWrapper
+
+@Tag(name = "활동 그룹 API", description = "활동 그룹 관련 API")
+interface ActivityGroupApi {
+    @Operation(
+        summary = "활동 그룹 생성",
+        description = "새로운 활동 그룹을 생성합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "활동 그룹 생성에 성공했습니다."),
+            ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+        ],
+    )
+    fun createActivityGroup(
+        @RequestBody request: ActivityGroupCreateRequest,
+    ): ResponseEntity<ResponseWrapper<Unit>>
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupApi.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupApi.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
 import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.activitygroup.entrypoint.response.ActivityGroupResponse
 import picklab.backend.common.model.ResponseWrapper
 
 @Tag(name = "활동 그룹 API", description = "활동 그룹 관련 API")
@@ -21,4 +22,13 @@ interface ActivityGroupApi {
     fun createActivityGroup(
         @RequestBody request: ActivityGroupCreateRequest,
     ): ResponseEntity<ResponseWrapper<Unit>>
+
+    @Operation(
+        summary = "활동 그룹 목록 조회",
+        description = "등록된 활동 그룹 목록을 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "활동 그룹 목록 조회에 성공했습니다."),
+        ],
+    )
+    fun getActivityGroups(): ResponseEntity<ResponseWrapper<List<ActivityGroupResponse>>>
 }

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupController.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupController.kt
@@ -2,12 +2,16 @@ package picklab.backend.activitygroup.entrypoint
 
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import picklab.backend.activitygroup.application.ActivityGroupQueryUseCase
 import picklab.backend.activitygroup.application.ActivityGroupUseCase
+import picklab.backend.activitygroup.entrypoint.mapper.toResponse
 import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.activitygroup.entrypoint.response.ActivityGroupResponse
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 
@@ -15,6 +19,7 @@ import picklab.backend.common.model.SuccessCode
 @RequestMapping("/v1/activity-groups")
 class ActivityGroupController(
     private val activityGroupUseCase: ActivityGroupUseCase,
+    private val activityGroupQueryUseCase: ActivityGroupQueryUseCase,
 ) : ActivityGroupApi {
     @PostMapping("")
     override fun createActivityGroup(
@@ -22,5 +27,11 @@ class ActivityGroupController(
     ): ResponseEntity<ResponseWrapper<Unit>> {
         activityGroupUseCase.createActivityGroup(request.toCommand())
         return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.CREATE_ACTIVITY_GROUP))
+    }
+
+    @GetMapping("")
+    override fun getActivityGroups(): ResponseEntity<ResponseWrapper<List<ActivityGroupResponse>>> {
+        val data = activityGroupQueryUseCase.getActivityGroups().map { it.toResponse() }
+        return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.GET_ACTIVITY_GROUPS, data))
     }
 }

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupController.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupController.kt
@@ -1,0 +1,26 @@
+package picklab.backend.activitygroup.entrypoint
+
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import picklab.backend.activitygroup.application.ActivityGroupUseCase
+import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.common.model.ResponseWrapper
+import picklab.backend.common.model.SuccessCode
+
+@RestController
+@RequestMapping("/v1/activity-groups")
+class ActivityGroupController(
+    private val activityGroupUseCase: ActivityGroupUseCase,
+) : ActivityGroupApi {
+    @PostMapping("")
+    override fun createActivityGroup(
+        @Valid @RequestBody request: ActivityGroupCreateRequest,
+    ): ResponseEntity<ResponseWrapper<Unit>> {
+        activityGroupUseCase.createActivityGroup(request.toCommand())
+        return ResponseEntity.ok(ResponseWrapper.success(SuccessCode.CREATE_ACTIVITY_GROUP))
+    }
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/mapper/ActivityGroupResponseMapper.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/mapper/ActivityGroupResponseMapper.kt
@@ -1,0 +1,11 @@
+package picklab.backend.activitygroup.entrypoint.mapper
+
+import picklab.backend.activitygroup.application.query.model.ActivityGroupView
+import picklab.backend.activitygroup.entrypoint.response.ActivityGroupResponse
+
+fun ActivityGroupView.toResponse(): ActivityGroupResponse =
+    ActivityGroupResponse(
+        id = id,
+        name = name,
+        description = description,
+    )

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/request/ActivityGroupCreateRequest.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/request/ActivityGroupCreateRequest.kt
@@ -1,0 +1,24 @@
+package picklab.backend.activitygroup.entrypoint.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import picklab.backend.activitygroup.application.model.ActivityGroupCreateCommand
+
+@Schema(description = "활동 그룹 생성 요청")
+data class ActivityGroupCreateRequest(
+    @field:NotBlank
+    @field:Size(max = 100)
+    @field:Schema(description = "활동 그룹 이름", example = "대외활동")
+    val name: String,
+    @field:NotBlank
+    @field:Size(max = 255)
+    @field:Schema(description = "활동 그룹 설명", example = "대외활동 관련 그룹입니다.")
+    val description: String,
+) {
+    fun toCommand(): ActivityGroupCreateCommand =
+        ActivityGroupCreateCommand(
+            name = name,
+            description = description,
+        )
+}

--- a/src/main/kotlin/picklab/backend/activitygroup/entrypoint/response/ActivityGroupResponse.kt
+++ b/src/main/kotlin/picklab/backend/activitygroup/entrypoint/response/ActivityGroupResponse.kt
@@ -1,0 +1,13 @@
+package picklab.backend.activitygroup.entrypoint.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "활동 그룹 응답")
+data class ActivityGroupResponse(
+    @field:Schema(description = "활동 그룹 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "활동 그룹 이름", example = "대외활동")
+    val name: String,
+    @field:Schema(description = "활동 그룹 설명", example = "대외활동 관련 그룹입니다.")
+    val description: String,
+)

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -30,6 +30,7 @@ enum class SuccessCode(
     GET_ACTIVITY_DETAIL(HttpStatus.OK, "활동 상세 조회에 성공했습니다."),
     CREATE_ACTIVITY(HttpStatus.OK, "활동 생성에 성공했습니다."),
     CREATE_ACTIVITY_GROUP(HttpStatus.OK, "활동 그룹 생성에 성공했습니다."),
+    GET_ACTIVITY_GROUPS(HttpStatus.OK, "활동 그룹 목록 조회에 성공했습니다."),
     ACTIVITY_BOOKMARK_CREATED(HttpStatus.CREATED, "북마크가 추가되었습니다."),
     ACTIVITY_BOOKMARK_REMOVED(HttpStatus.OK, "북마크가 삭제되었습니다."),
     GET_BOOKMARKS(HttpStatus.OK, "북마크 목록 조회에 성공했습니다."),

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -6,63 +6,64 @@ enum class SuccessCode(
     val status: HttpStatus,
     val message: String,
 ) {
-    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "소셜 로그인 성공"),
+    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "소셜 로그인에 성공했습니다."),
     JOB_DETAILS_RETRIEVED(HttpStatus.OK, "직무 상세 목록 조회에 성공했습니다."),
     SIGNUP_SUCCESS(HttpStatus.OK, "회원 가입에 성공했습니다."),
-    ACCESS_TOKEN_REFRESHED(HttpStatus.OK, "액세스 토큰 재발급 성공"),
+    ACCESS_TOKEN_REFRESHED(HttpStatus.OK, "액세스 토큰 재발급에 성공했습니다."),
 
-    // Member 도메인 관련
+    // Member 관련
     MEMBER_INFO_UPDATED(HttpStatus.OK, "회원 정보 수정에 성공했습니다."),
     MEMBER_JOB_CATEGORY_UPDATED(HttpStatus.OK, "관심 직무 수정에 성공했습니다."),
     MEMBER_PROFILE_IMAGE_UPDATED(HttpStatus.OK, "프로필 이미지 변경에 성공했습니다."),
     MEMBER_EMAIL_UPDATED(HttpStatus.OK, "이메일 변경에 성공했습니다."),
-    SEND_EMAIL_CODE(HttpStatus.OK, "인증 코드 발송에 성공했습니다."),
+    SEND_EMAIL_CODE(HttpStatus.OK, "인증 코드를 발송했습니다."),
     VERIFY_EMAIL_CODE(HttpStatus.OK, "이메일 코드 인증에 성공했습니다."),
-    UPDATE_EMAIL_AGREEMENT(HttpStatus.OK, "이메일 마케팅 수신 동의 정보 수정에 성공했습니다."),
+    UPDATE_EMAIL_AGREEMENT(HttpStatus.OK, "이메일 마케팅 수신 동의 정보를 수정했습니다."),
     GET_MEMBER_SOCIAL_LOGINS(HttpStatus.OK, "소셜 로그인 연동 정보 조회에 성공했습니다."),
     GET_MEMBER_ME(HttpStatus.OK, "내 정보 조회에 성공했습니다."),
     MEMBER_WITHDRAW(HttpStatus.OK, "회원 탈퇴에 성공했습니다."),
     SUBMIT_SURVEY(HttpStatus.OK, "탈퇴 설문 제출에 성공했습니다."),
     MEMBER_NOTIFICATION_UPDATED(HttpStatus.OK, "알림 변경에 성공했습니다."),
 
-    // Activity 도메인 관련
+    // Activity 관련
     GET_ACTIVITIES(HttpStatus.OK, "활동 목록 조회에 성공했습니다."),
     GET_ACTIVITY_DETAIL(HttpStatus.OK, "활동 상세 조회에 성공했습니다."),
     CREATE_ACTIVITY(HttpStatus.OK, "활동 생성에 성공했습니다."),
+    CREATE_ACTIVITY_GROUP(HttpStatus.OK, "활동 그룹 생성에 성공했습니다."),
     ACTIVITY_BOOKMARK_CREATED(HttpStatus.CREATED, "북마크가 추가되었습니다."),
     ACTIVITY_BOOKMARK_REMOVED(HttpStatus.OK, "북마크가 삭제되었습니다."),
     GET_BOOKMARKS(HttpStatus.OK, "북마크 목록 조회에 성공했습니다."),
-    INCREASE_VIEW_COUNT(HttpStatus.OK, "조회수 증가에 성공했습니다."),
+    INCREASE_VIEW_COUNT(HttpStatus.OK, "조회 수 증가에 성공했습니다."),
 
-    // Archive 도메인 관련
+    // Archive 관련
     CREATE_ARCHIVE_SUCCESS(HttpStatus.OK, "아카이브 생성에 성공했습니다."),
     UPDATE_ARCHIVE_SUCCESS(HttpStatus.OK, "아카이브 수정에 성공했습니다."),
 
-    // Notification 도메인 관련
+    // Notification 관련
     SEND_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림 전송에 성공했습니다."),
     GET_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 목록 조회에 성공했습니다."),
     GET_RECENT_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "최근 알림 목록 조회에 성공했습니다."),
     MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
     MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
-    DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림이 삭제되었습니다."),
+    DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림을 삭제했습니다."),
 
-    // Review 도메인 관련
+    // Review 관련
     GET_REVIEW(HttpStatus.OK, "리뷰 단건 조회에 성공했습니다."),
     GET_REVIEWS(HttpStatus.OK, "리뷰 목록 조회에 성공했습니다."),
     CREATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 생성에 성공했습니다."),
-    UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정을 성공했습니다."),
-    DELETE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 삭제를 성공했습니다."),
-    GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS(HttpStatus.OK, "직무 연관성 평균 점수 조회에 성공했습니다."),
+    UPDATE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 수정에 성공했습니다."),
+    DELETE_REVIEW_SUCCESS(HttpStatus.OK, "리뷰 삭제에 성공했습니다."),
+    GET_JOB_RELEVANCE_AVG_SCORES_SUCCESS(HttpStatus.OK, "직무 관련도 평균 점수 조회에 성공했습니다."),
     GET_SATISFACTION_AVG_SCORES_SUCCESS(HttpStatus.OK, "활동별 만족도 통계 조회에 성공했습니다."),
 
-    // Search 도메인 관련
+    // Search 관련
     SEARCH_AUTOCOMPLETE_SUCCESS(HttpStatus.OK, "자동완성 검색에 성공했습니다."),
-    SEARCH_HISTORY_CREATED(HttpStatus.CREATED, "검색 기록이 생성되었습니다."),
+    SEARCH_HISTORY_CREATED(HttpStatus.CREATED, "검색 기록을 생성했습니다."),
     SEARCH_HISTORY_RETRIEVED(HttpStatus.OK, "검색 기록 조회에 성공했습니다."),
     RECENT_KEYWORDS_RETRIEVED(HttpStatus.OK, "최근 검색어 조회에 성공했습니다."),
-    SEARCH_HISTORY_DELETED(HttpStatus.OK, "검색 기록이 삭제되었습니다."),
-    SEARCH_HISTORY_ALL_DELETED(HttpStatus.OK, "모든 검색 기록이 삭제되었습니다."),
+    SEARCH_HISTORY_DELETED(HttpStatus.OK, "검색 기록을 삭제했습니다."),
+    SEARCH_HISTORY_ALL_DELETED(HttpStatus.OK, "모든 검색 기록을 삭제했습니다."),
 
     // File Upload 관련
-    GET_PRESIGNED_URL(HttpStatus.OK, "Presigned url 발급에 성공했습니다."),
+    GET_PRESIGNED_URL(HttpStatus.OK, "Presigned URL 발급에 성공했습니다."),
 }

--- a/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import picklab.backend.activity.application.ViewCountLimiterPort.Companion.MAX_VIEW_ATTEMPTS
 import picklab.backend.activity.domain.entity.ActivityBookmark
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ActivityJobCategory
 import picklab.backend.activity.domain.entity.CompetitionActivity
 import picklab.backend.activity.domain.entity.EducationActivity
@@ -26,11 +25,12 @@ import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
 import picklab.backend.activity.domain.repository.ActivityBookmarkRepository
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityJobCategoryRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
 import picklab.backend.activity.entrypoint.response.GetActivityDetailResponse
 import picklab.backend.activity.entrypoint.response.GetActivityListResponse
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.helper.WithMockUser

--- a/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/activity/ActivityIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import picklab.backend.activity.application.ViewCountLimiterPort.Companion.MAX_VIEW_ATTEMPTS
@@ -84,6 +85,54 @@ class ActivityIntegrationTest : IntegrationTest() {
                     description = "테스트 그룹 설명",
                 ),
             )
+    }
+
+    @Nested
+    @DisplayName("활동 생성 통합 테스트")
+    inner class CreateActivityTest {
+        @Test
+        @WithMockUser
+        @DisplayName("[성공] snake_case activity_type 으로 대외활동을 생성한다.")
+        fun `snake_case activity_type 으로 대외활동을 생성한다`() {
+            val requestBody =
+                """
+                {
+                  "activity_type": "EXTRACURRICULAR",
+                  "activity_group_id": ${activityGroup.id},
+                  "title": "활동명",
+                  "organizer": "LARGE_CORPORATION",
+                  "target_audience": "ALL",
+                  "recruitment_start_date": "2026-04-01",
+                  "recruitment_end_date": "2026-05-01",
+                  "start_date": "2026-05-01",
+                  "end_date": "2026-11-01",
+                  "status": "OPEN",
+                  "duration": 180,
+                  "activity_homepage_url": "homepage_url",
+                  "activity_application_url": "app_url",
+                  "activity_thumbnail_url": "thumbnail_url",
+                  "description": "설명",
+                  "benefit": "활동혜택",
+                  "job_categories": [],
+                  "upload_files": [],
+                  "location": "SEOUL_INCHEON",
+                  "activity_field": "MENTORING"
+                }
+                """.trimIndent()
+
+            mockMvc
+                .post("/v1/activities") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody
+                }.andExpect { status { isOk() } }
+                .andExpect { jsonPath("$.code") { value(SuccessCode.CREATE_ACTIVITY.status.value()) } }
+                .andExpect { jsonPath("$.message") { value(SuccessCode.CREATE_ACTIVITY.message) } }
+
+            val savedActivities = activityRepository.findAll()
+            assertThat(savedActivities).hasSize(1)
+            assertThat(savedActivities.first().title).isEqualTo("활동명")
+            assertThat(savedActivities.first().activityType).isEqualTo(ActivityType.EXTRACURRICULAR.name)
+        }
     }
 
     @Nested

--- a/src/test/kotlin/picklab/backend/activity/service/ActivityDeadlineServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/activity/service/ActivityDeadlineServiceTest.kt
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ExternalActivity
 import picklab.backend.activity.domain.enums.ActivityFieldType
 import picklab.backend.activity.domain.enums.LocationType
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
 import picklab.backend.activity.domain.service.ActivityService
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.template.IntegrationTest
 import java.time.LocalDate
 

--- a/src/test/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupControllerTest.kt
+++ b/src/test/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupControllerTest.kt
@@ -7,11 +7,16 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.activitygroup.entrypoint.response.ActivityGroupResponse
+import picklab.backend.common.model.ResponseWrapper
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.helper.WithMockUser
+import picklab.backend.helper.extractBody
 import picklab.backend.template.IntegrationTest
 
 @WithMockUser
@@ -48,6 +53,53 @@ class ActivityGroupControllerTest : IntegrationTest() {
             assertThat(saved).hasSize(1)
             assertThat(saved[0].name).isEqualTo(request.name)
             assertThat(saved[0].description).isEqualTo(request.description)
+        }
+    }
+
+    @Nested
+    @DisplayName("활동 그룹 목록 조회")
+    inner class GetActivityGroups {
+        @Test
+        @DisplayName("[성공] 활동 그룹 목록을 조회한다.")
+        fun success() {
+            val first =
+                activityGroupRepository.save(
+                    ActivityGroup(
+                        name = "대외활동",
+                        description = "대외활동 관련 그룹입니다.",
+                    ),
+                )
+            val second =
+                activityGroupRepository.save(
+                    ActivityGroup(
+                        name = "교육",
+                        description = "교육 관련 그룹입니다.",
+                    ),
+                )
+
+            val result =
+                mockMvc
+                    .get("/v1/activity-groups")
+                    .andExpect { status { isOk() } }
+                    .andExpect { jsonPath("$.code") { value(SuccessCode.GET_ACTIVITY_GROUPS.status.value()) } }
+                    .andExpect { jsonPath("$.message") { value(SuccessCode.GET_ACTIVITY_GROUPS.message) } }
+                    .andReturn()
+
+            val body: ResponseWrapper<List<ActivityGroupResponse>> = result.extractBody(mapper)
+            val got = body.data!!
+
+            assertThat(got).containsExactly(
+                ActivityGroupResponse(
+                    id = first.id,
+                    name = first.name,
+                    description = first.description,
+                ),
+                ActivityGroupResponse(
+                    id = second.id,
+                    name = second.name,
+                    description = second.description,
+                ),
+            )
         }
     }
 }

--- a/src/test/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupControllerTest.kt
+++ b/src/test/kotlin/picklab/backend/activitygroup/entrypoint/ActivityGroupControllerTest.kt
@@ -1,0 +1,53 @@
+package picklab.backend.activitygroup.entrypoint
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
+import picklab.backend.activitygroup.entrypoint.request.ActivityGroupCreateRequest
+import picklab.backend.common.model.SuccessCode
+import picklab.backend.helper.WithMockUser
+import picklab.backend.template.IntegrationTest
+
+@WithMockUser
+class ActivityGroupControllerTest : IntegrationTest() {
+    @Autowired
+    lateinit var activityGroupRepository: ActivityGroupRepository
+
+    @BeforeEach
+    fun setUp() {
+        cleanUp.all()
+    }
+
+    @Nested
+    @DisplayName("활동 그룹 생성")
+    inner class CreateActivityGroup {
+        @Test
+        @DisplayName("[성공] 활동 그룹을 생성한다.")
+        fun success() {
+            val request =
+                ActivityGroupCreateRequest(
+                    name = "대외활동",
+                    description = "대외활동 관련 그룹입니다.",
+                )
+
+            mockMvc
+                .post("/v1/activity-groups") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = mapper.writeValueAsString(request)
+                }.andExpect { status { isOk() } }
+                .andExpect { jsonPath("$.code") { value(SuccessCode.CREATE_ACTIVITY_GROUP.status.value()) } }
+                .andExpect { jsonPath("$.message") { value(SuccessCode.CREATE_ACTIVITY_GROUP.message) } }
+
+            val saved = activityGroupRepository.findAll()
+            assertThat(saved).hasSize(1)
+            assertThat(saved[0].name).isEqualTo(request.name)
+            assertThat(saved[0].description).isEqualTo(request.description)
+        }
+    }
+}

--- a/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.post
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.entity.ActivityBookmark
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ExternalActivity
 import picklab.backend.activity.domain.enums.ActivityFieldType
 import picklab.backend.activity.domain.enums.LocationType
@@ -18,8 +17,9 @@ import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
 import picklab.backend.activity.domain.repository.ActivityBookmarkRepository
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.common.model.ErrorCode
 import picklab.backend.common.model.SuccessCode
 import picklab.backend.helper.WithMockUser

--- a/src/test/kotlin/picklab/backend/notification/domain/service/ActivityDeadlineNotificationServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/notification/domain/service/ActivityDeadlineNotificationServiceTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.entity.ActivityBookmark
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ExternalActivity
 import picklab.backend.activity.domain.enums.ActivityFieldType
 import picklab.backend.activity.domain.enums.LocationType
@@ -15,8 +14,9 @@ import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
 import picklab.backend.activity.domain.repository.ActivityBookmarkRepository
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.member.domain.entity.Member
 import picklab.backend.member.domain.entity.NotificationPreference
 import picklab.backend.member.domain.repository.MemberRepository

--- a/src/test/kotlin/picklab/backend/notification/domain/service/PopularActivityNotificationServiceTest.kt
+++ b/src/test/kotlin/picklab/backend/notification/domain/service/PopularActivityNotificationServiceTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.entity.ActivityBookmark
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.entity.ExternalActivity
 import picklab.backend.activity.domain.enums.ActivityFieldType
 import picklab.backend.activity.domain.enums.LocationType
@@ -15,8 +14,9 @@ import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
 import picklab.backend.activity.domain.repository.ActivityBookmarkRepository
-import picklab.backend.activity.domain.repository.ActivityGroupRepository
 import picklab.backend.activity.domain.repository.ActivityRepository
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
+import picklab.backend.activitygroup.domain.repository.ActivityGroupRepository
 import picklab.backend.member.domain.entity.Member
 import picklab.backend.member.domain.entity.NotificationPreference
 import picklab.backend.member.domain.repository.MemberRepository

--- a/src/test/kotlin/picklab/backend/participation/domain/entity/ActivityParticipationTest.kt
+++ b/src/test/kotlin/picklab/backend/participation/domain/entity/ActivityParticipationTest.kt
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import picklab.backend.activity.domain.entity.Activity
-import picklab.backend.activity.domain.entity.ActivityGroup
 import picklab.backend.activity.domain.enums.OrganizerType
 import picklab.backend.activity.domain.enums.ParticipantType
 import picklab.backend.activity.domain.enums.RecruitmentStatus
+import picklab.backend.activitygroup.domain.entity.ActivityGroup
 import picklab.backend.member.domain.entity.Member
 import picklab.backend.participation.domain.enums.ApplicationStatus
 import picklab.backend.participation.domain.enums.ProgressStatus


### PR DESCRIPTION
## PR 설명
- [✨ feat: 활동 그룹 생성 API 추가](https://github.com/picklab/picklab-be/commit/4ffd1898382cb63b5d4653d0091b515b9d619512)
- [✨ feat: 활동 그룹 목록 조회 API 추가](https://github.com/picklab/picklab-be/commit/81a512b3a57f192db6fe31ed27fb869f3a824a3b)

## 작업 내용
- 활동 그룹 생성, 조회 API를 추가했습니다.
- 활동 생성 요청에서 다형성 discriminator를 입력 요청 시  camel case에서  `activity_type` snake case로 읽히도록 수정했습니다.
- 위 활동 생성 요청이 정상 동작하는 통합 테스트를 추가했습니다.