### PR TITLE
✨ feat: 저장 공고 날짜 응답 및 알림 개별 삭제 API 추가

### DIFF
--- a/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityQueryRepository.kt
@@ -3,6 +3,7 @@ package picklab.backend.activity.application
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import picklab.backend.activity.application.model.ActivityView
+import picklab.backend.activity.application.model.BookmarkedActivityView
 import picklab.backend.activity.application.model.GetMyBookmarkListCondition
 
 interface ActivityQueryRepository {
@@ -17,7 +18,7 @@ interface ActivityQueryRepository {
         memberId: Long,
         queryData: GetMyBookmarkListCondition,
         pageable: PageRequest,
-    ): Page<ActivityView>
+    ): Page<BookmarkedActivityView>
 
     fun findRecentlyViewedActivities(
         memberId: Long,

--- a/src/main/kotlin/picklab/backend/activity/application/ActivityQueryService.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/ActivityQueryService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import picklab.backend.activity.application.model.ActivityView
+import picklab.backend.activity.application.model.BookmarkedActivityView
 import picklab.backend.activity.application.model.GetMyBookmarkListCondition
 
 @Service
@@ -19,7 +20,7 @@ class ActivityQueryService(
         memberId: Long,
         queryData: GetMyBookmarkListCondition,
         pageable: PageRequest,
-    ): Page<ActivityView> = activityQueryRepository.findActivityItemByMemberBookmarked(memberId, queryData, pageable)
+    ): Page<BookmarkedActivityView> = activityQueryRepository.findActivityItemByMemberBookmarked(memberId, queryData, pageable)
 
     fun getRecentlyViewedActivities(
         memberId: Long,

--- a/src/main/kotlin/picklab/backend/activity/application/BookmarkUseCase.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/BookmarkUseCase.kt
@@ -4,8 +4,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import picklab.backend.activity.application.mapper.withBookmark
-import picklab.backend.activity.application.model.ActivityItemWithBookmark
+import picklab.backend.activity.application.mapper.toBookmarkedActivityItem
+import picklab.backend.activity.application.model.BookmarkedActivityItem
 import picklab.backend.activity.application.model.GetMyBookmarkListCondition
 import picklab.backend.activity.domain.service.ActivityBookmarkService
 import picklab.backend.activity.domain.service.ActivityService
@@ -41,12 +41,12 @@ class BookmarkUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getBookmarks(condition: GetMyBookmarkListCondition): Page<ActivityItemWithBookmark> {
+    fun getBookmarks(condition: GetMyBookmarkListCondition): Page<BookmarkedActivityItem> {
         val member = memberService.findActiveMember(condition.memberId)
         val pageable = PageRequest.of(condition.page, condition.size)
 
         val bookmarkedActivityPage = activityQueryService.getBookmarkedActivityItems(member.id, condition, pageable)
 
-        return bookmarkedActivityPage.map { it.withBookmark(true) }
+        return bookmarkedActivityPage.map { it.toBookmarkedActivityItem() }
     }
 }

--- a/src/main/kotlin/picklab/backend/activity/application/mapper/ActivityItemMapper.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/mapper/ActivityItemMapper.kt
@@ -2,18 +2,18 @@ package picklab.backend.activity.application.mapper
 
 import picklab.backend.activity.application.model.ActivityItemWithBookmark
 import picklab.backend.activity.application.model.ActivityView
+import picklab.backend.activity.application.model.BookmarkedActivityItem
+import picklab.backend.activity.application.model.BookmarkedActivityView
 import picklab.backend.activity.domain.enums.RecruitmentEndType
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 fun ActivityView.withBookmark(isBookmarked: Boolean): ActivityItemWithBookmark {
-    val today = LocalDate.now()
     val dDay =
-        if (recruitmentEndType == RecruitmentEndType.FIXED) {
-            recruitmentEndDate?.let { ChronoUnit.DAYS.between(today, it) }
-        } else {
-            null
-        }
+        recruitmentEndDate
+            ?.takeIf { recruitmentEndType == RecruitmentEndType.FIXED }
+            ?.let { ChronoUnit.DAYS.between(LocalDate.now(), it) }
+
     return ActivityItemWithBookmark(
         id,
         title,
@@ -27,5 +27,30 @@ fun ActivityView.withBookmark(isBookmarked: Boolean): ActivityItemWithBookmark {
         recruitmentEndType,
         dDay,
         isBookmarked,
+    )
+}
+
+fun BookmarkedActivityView.toBookmarkedActivityItem(): BookmarkedActivityItem {
+    val dDay =
+        recruitmentEndDate
+            ?.takeIf { recruitmentEndType == RecruitmentEndType.FIXED }
+            ?.let { ChronoUnit.DAYS.between(LocalDate.now(), it) }
+
+    return BookmarkedActivityItem(
+        id = id,
+        title = title,
+        organization = organization,
+        organizerType = organizerType,
+        startDate = startDate,
+        recruitmentStartDate = recruitmentStartDate,
+        recruitmentEndDate = recruitmentEndDate,
+        category = category,
+        jobTags = jobTags,
+        thumbnailUrl = thumbnailUrl,
+        viewCount = viewCount,
+        recruitmentEndType = recruitmentEndType,
+        dDay = dDay,
+        isBookmarked = true,
+        bookmarkedAt = bookmarkedAt.toLocalDate(),
     )
 }

--- a/src/main/kotlin/picklab/backend/activity/application/model/BookmarkedActivityItem.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/model/BookmarkedActivityItem.kt
@@ -1,0 +1,38 @@
+package picklab.backend.activity.application.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import picklab.backend.activity.domain.enums.RecruitmentEndType
+import java.time.LocalDate
+
+data class BookmarkedActivityItem(
+    @field:Schema(description = "활동 ID")
+    val id: Long,
+    @field:Schema(description = "활동명")
+    val title: String,
+    @field:Schema(description = "주최기관/단체명")
+    val organization: String?,
+    @field:Schema(description = "주최기관 유형")
+    val organizerType: String,
+    @field:Schema(description = "활동 시작일")
+    val startDate: LocalDate,
+    @field:Schema(description = "지원 시작일")
+    val recruitmentStartDate: LocalDate,
+    @field:Schema(description = "지원 마감일")
+    val recruitmentEndDate: LocalDate?,
+    @field:Schema(description = "활동 유형 (EXTRACURRICULAR, COMPETITION, SEMINAR, EDUCATION)")
+    val category: String,
+    @field:Schema(description = "직무 태그 목록")
+    val jobTags: List<String>,
+    @field:Schema(description = "활동 썸네일 이미지 URL")
+    val thumbnailUrl: String?,
+    @field:Schema(description = "조회수")
+    val viewCount: Long,
+    @field:Schema(description = "모집 종료 유형 (FIXED: 날짜 지정, ALWAYS_OPEN: 상시모집, CLOSE_ON_HIRE: 채용시마감)")
+    val recruitmentEndType: RecruitmentEndType,
+    @field:Schema(description = "모집 마감까지 남은 일수 (상시모집·채용시마감은 null)")
+    val dDay: Long?,
+    @field:Schema(description = "북마크 여부")
+    val isBookmarked: Boolean,
+    @field:Schema(description = "북마크한 날짜")
+    val bookmarkedAt: LocalDate,
+)

--- a/src/main/kotlin/picklab/backend/activity/application/model/BookmarkedActivityView.kt
+++ b/src/main/kotlin/picklab/backend/activity/application/model/BookmarkedActivityView.kt
@@ -1,0 +1,9 @@
+package picklab.backend.activity.application.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+interface BookmarkedActivityView : ActivityView {
+    val recruitmentStartDate: LocalDate
+    val bookmarkedAt: LocalDateTime
+}

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityBookmarkApi.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityBookmarkApi.kt
@@ -8,7 +8,7 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
-import picklab.backend.activity.application.model.ActivityItemWithBookmark
+import picklab.backend.activity.application.model.BookmarkedActivityItem
 import picklab.backend.activity.entrypoint.request.GetMyBookmarkListRequest
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.PageResponse
@@ -54,5 +54,5 @@ interface ActivityBookmarkApi {
     fun getBookmarks(
         @AuthenticationPrincipal member: MemberPrincipal,
         @Valid @ParameterObject request: GetMyBookmarkListRequest,
-    ): ResponseEntity<ResponseWrapper<PageResponse<ActivityItemWithBookmark>>>
+    ): ResponseEntity<ResponseWrapper<PageResponse<BookmarkedActivityItem>>>
 }

--- a/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityBookmarkController.kt
+++ b/src/main/kotlin/picklab/backend/activity/entrypoint/ActivityBookmarkController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import picklab.backend.activity.application.BookmarkUseCase
-import picklab.backend.activity.application.model.ActivityItemWithBookmark
+import picklab.backend.activity.application.model.BookmarkedActivityItem
 import picklab.backend.activity.entrypoint.request.GetMyBookmarkListRequest
 import picklab.backend.common.model.MemberPrincipal
 import picklab.backend.common.model.PageResponse
@@ -52,7 +52,7 @@ class ActivityBookmarkController(
     override fun getBookmarks(
         @AuthenticationPrincipal member: MemberPrincipal,
         @Valid @ParameterObject request: GetMyBookmarkListRequest,
-    ): ResponseEntity<ResponseWrapper<PageResponse<ActivityItemWithBookmark>>> =
+    ): ResponseEntity<ResponseWrapper<PageResponse<BookmarkedActivityItem>>> =
         bookmarkUseCase
             .getBookmarks(request.toCondition(member.memberId))
             .toPageResponse()

--- a/src/main/kotlin/picklab/backend/activity/infrastructure/ActivityQueryRepositoryImpl.kt
+++ b/src/main/kotlin/picklab/backend/activity/infrastructure/ActivityQueryRepositoryImpl.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import picklab.backend.activity.application.ActivityQueryRepository
 import picklab.backend.activity.application.model.ActivityView
+import picklab.backend.activity.application.model.BookmarkedActivityView
 import picklab.backend.activity.application.model.GetMyBookmarkListCondition
 import picklab.backend.activity.domain.entity.QActivity
 import picklab.backend.activity.domain.entity.QActivityBookmark
@@ -217,7 +218,7 @@ class ActivityQueryRepositoryImpl(
         memberId: Long,
         queryData: GetMyBookmarkListCondition,
         pageable: PageRequest,
-    ): Page<ActivityView> {
+    ): Page<BookmarkedActivityView> {
         val condition =
             BooleanBuilder().apply {
                 and(
@@ -283,21 +284,23 @@ class ActivityQueryRepositoryImpl(
                 .limit(pageable.pageSize.toLong())
                 .transform(
                     GroupBy.groupBy(QActivity.activity.id).list(
-                        QActivityItem(
+                        QBookmarkedActivityItemView(
                             QActivity.activity.id,
                             QActivity.activity.title,
                             QActivity.activity.organizer,
                             QActivity.activity.organizerType.stringValue(),
                             QActivity.activity.startDate,
+                            QActivity.activity.recruitmentStartDate,
                             QActivity.activity.activityType,
                             GroupBy.list(QJobCategory.jobCategory.jobDetail.stringValue()),
                             QActivity.activity.activityThumbnailUrl,
                             QActivity.activity.viewCount,
                             QActivity.activity.recruitmentEndDate,
                             QActivity.activity.recruitmentEndType,
+                            QActivityBookmark.activityBookmark.createdAt,
                         ),
                     ),
-                ).map { it as ActivityView }
+                ).map { it as BookmarkedActivityView }
 
         val count =
             jpaQueryFactory

--- a/src/main/kotlin/picklab/backend/activity/infrastructure/BookmarkedActivityItemView.kt
+++ b/src/main/kotlin/picklab/backend/activity/infrastructure/BookmarkedActivityItemView.kt
@@ -1,0 +1,24 @@
+package picklab.backend.activity.infrastructure
+
+import com.querydsl.core.annotations.QueryProjection
+import picklab.backend.activity.application.model.BookmarkedActivityView
+import picklab.backend.activity.domain.enums.RecruitmentEndType
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@QueryProjection
+data class BookmarkedActivityItemView(
+    override val id: Long,
+    override val title: String,
+    override val organization: String?,
+    override val organizerType: String,
+    override val startDate: LocalDate,
+    override val recruitmentStartDate: LocalDate,
+    override val category: String,
+    override val jobTags: List<String>,
+    override val thumbnailUrl: String?,
+    override val viewCount: Long,
+    override val recruitmentEndDate: LocalDate?,
+    override val recruitmentEndType: RecruitmentEndType,
+    override val bookmarkedAt: LocalDateTime,
+) : BookmarkedActivityView

--- a/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
+++ b/src/main/kotlin/picklab/backend/common/model/SuccessCode.kt
@@ -55,6 +55,7 @@ enum class SuccessCode(
     GET_RECENT_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "최근 알림 목록 조회에 성공했습니다."),
     MARK_NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림 읽음 처리에 성공했습니다."),
     MARK_ALL_NOTIFICATIONS_READ_SUCCESS(HttpStatus.OK, "모든 알림 읽음 처리에 성공했습니다."),
+    DELETE_NOTIFICATION_SUCCESS(HttpStatus.OK, "알림을 삭제했습니다."),
     DELETE_ALL_MEMBER_NOTIFICATION(HttpStatus.OK, "모든 알림을 삭제했습니다."),
 
     // Review 관련

--- a/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
+++ b/src/main/kotlin/picklab/backend/notification/application/NotificationUseCase.kt
@@ -57,6 +57,14 @@ class NotificationUseCase(
     fun markAllAsRead(memberId: Long): Int = notificationService.markAllAsRead(memberId)
 
     @Transactional
+    fun deleteByMember(
+        notificationId: Long,
+        memberId: Long,
+    ) {
+        notificationService.deleteByMember(notificationId, memberId)
+    }
+
+    @Transactional
     fun deleteAllByMember(memberId: Long) {
         val member = memberService.findActiveMember(memberId)
         val notifications = notificationService.findAllByMember(member)

--- a/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
+++ b/src/main/kotlin/picklab/backend/notification/domain/service/NotificationService.kt
@@ -154,6 +154,19 @@ class NotificationService(
      */
     fun markAllAsRead(memberId: Long): Int = notificationRepository.markAllAsReadByMemberId(memberId)
 
+    fun deleteByMember(
+        notificationId: Long,
+        memberId: Long,
+    ) {
+        val notification =
+            notificationRepository.findByIdAndMemberId(notificationId, memberId)
+                ?: throw BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND)
+
+        notification.read()
+        notification.delete()
+        notificationRepository.save(notification)
+    }
+
     fun findAllByMember(member: Member): List<Notification> = notificationRepository.findAllByMember(member)
 
     fun saveAll(entities: List<Notification>): List<Notification> = notificationRepository.saveAll(entities)

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationApi.kt
@@ -72,4 +72,14 @@ interface NotificationApi {
     )
     @ApiResponse(responseCode = "200", description = "모든 알림 삭제 처리 성공")
     fun deleteAllByMember(memberPrincipal: MemberPrincipal): ResponseWrapper<Unit>
+
+    @Operation(
+        summary = "알림 삭제 처리",
+        description = "현재 로그인한 사용자의 특정 알림을 삭제 처리합니다.",
+    )
+    @ApiResponse(responseCode = "200", description = "알림 삭제 처리 성공")
+    fun deleteByMember(
+        @Parameter(description = "알림 ID") notificationId: Long,
+        memberPrincipal: MemberPrincipal,
+    ): ResponseWrapper<Unit>
 }

--- a/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
+++ b/src/main/kotlin/picklab/backend/notification/entrypoint/NotificationController.kt
@@ -82,4 +82,13 @@ class NotificationController(
         notificationUseCase.deleteAllByMember(memberPrincipal.memberId)
         return ResponseWrapper.success(SuccessCode.DELETE_ALL_MEMBER_NOTIFICATION)
     }
+
+    @DeleteMapping("/notifications/{notificationId}")
+    override fun deleteByMember(
+        @PathVariable notificationId: Long,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+    ): ResponseWrapper<Unit> {
+        notificationUseCase.deleteByMember(notificationId, memberPrincipal.memberId)
+        return ResponseWrapper.success(SuccessCode.DELETE_NOTIFICATION_SUCCESS)
+    }
 }

--- a/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/bookmark/BookmarkIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import picklab.backend.activity.domain.entity.Activity
 import picklab.backend.activity.domain.entity.ActivityBookmark
@@ -171,6 +172,44 @@ class BookmarkIntegrationTest : IntegrationTest() {
                     }.andExpect { status { isNotFound() } }
                     .andExpect { jsonPath("$.code") { value(ErrorCode.NOT_FOUND_ACTIVITY_BOOKMARK.status.value()) } }
                     .andExpect { jsonPath("$.message") { value(ErrorCode.NOT_FOUND_ACTIVITY_BOOKMARK.message) } }
+            }
+        }
+
+        @Nested
+        @DisplayName("북마크 목록 조회 테스트")
+        inner class GetBookmarkListTests {
+            @Test
+            @DisplayName("[성공] 북마크 목록에 지원 시작일, 지원 마감일, 북마크한 날짜가 포함된다")
+            fun getBookmarkListWithDateFieldsSuccess() {
+                // given
+                val bookmark =
+                    activityBookmarkRepository.saveAndFlush(
+                        ActivityBookmark(
+                            member = member,
+                            activity = activity,
+                        ),
+                    )
+
+                // when & then
+                mockMvc
+                    .get("/v1/bookmarks")
+                    .andExpect { status { isOk() } }
+                    .andExpect { jsonPath("$.code") { value(SuccessCode.GET_BOOKMARKS.status.value()) } }
+                    .andExpect { jsonPath("$.message") { value(SuccessCode.GET_BOOKMARKS.message) } }
+                    .andExpect { jsonPath("$.data.items[0].id") { value(activity.id) } }
+                    .andExpect {
+                        jsonPath("$.data.items[0].recruitment_start_date") {
+                            value(activity.recruitmentStartDate.toString())
+                        }
+                    }.andExpect {
+                        jsonPath("$.data.items[0].recruitment_end_date") {
+                            value(activity.recruitmentEndDate.toString())
+                        }
+                    }.andExpect {
+                        jsonPath("$.data.items[0].bookmarked_at") {
+                            value(bookmark.createdAt.toLocalDate().toString())
+                        }
+                    }
             }
         }
     }

--- a/src/test/kotlin/picklab/backend/notification/NotificationIntegrationTest.kt
+++ b/src/test/kotlin/picklab/backend/notification/NotificationIntegrationTest.kt
@@ -1,0 +1,108 @@
+package picklab.backend.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.delete
+import picklab.backend.common.model.ErrorCode
+import picklab.backend.common.model.SuccessCode
+import picklab.backend.helper.WithMockUser
+import picklab.backend.member.domain.entity.Member
+import picklab.backend.member.domain.repository.MemberRepository
+import picklab.backend.notification.domain.entity.Notification
+import picklab.backend.notification.domain.entity.NotificationType
+import picklab.backend.notification.domain.repository.NotificationRepository
+import picklab.backend.template.IntegrationTest
+
+class NotificationIntegrationTest : IntegrationTest() {
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    lateinit var notificationRepository: NotificationRepository
+
+    lateinit var member: Member
+
+    @BeforeEach
+    fun setUp() {
+        cleanUp.all()
+
+        member =
+            memberRepository.save(
+                Member(
+                    name = "테스트 유저",
+                    email = "test@example.com",
+                ),
+            )
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("알림 삭제 테스트")
+    inner class DeleteNotificationTests {
+        @Test
+        @DisplayName("[성공] 내 알림을 개별 삭제한다")
+        fun deleteNotificationSuccess() {
+            // given
+            val notification =
+                notificationRepository.saveAndFlush(
+                    Notification(
+                        title = "테스트 알림",
+                        type = NotificationType.ACTIVITY_CREATED,
+                        link = "/activities/1",
+                        member = member,
+                    ),
+                )
+
+            // when
+            mockMvc
+                .delete("/notifications/${notification.id}")
+                .andExpect { status { isOk() } }
+                .andExpect { jsonPath("$.code") { value(SuccessCode.DELETE_NOTIFICATION_SUCCESS.status.value()) } }
+                .andExpect { jsonPath("$.message") { value(SuccessCode.DELETE_NOTIFICATION_SUCCESS.message) } }
+
+            // then
+            val deletedNotification = notificationRepository.findByIdIgnoreDelete(notification.id)
+            assertThat(deletedNotification).isNotNull
+            assertThat(deletedNotification!!.isRead).isTrue
+            assertThat(deletedNotification.deletedAt).isNotNull
+            assertThat(notificationRepository.findById(notification.id)).isEmpty
+        }
+
+        @Test
+        @DisplayName("[실패] 다른 사용자의 알림은 삭제할 수 없다")
+        fun cannotDeleteOtherMemberNotification() {
+            // given
+            val otherMember =
+                memberRepository.save(
+                    Member(
+                        name = "다른 유저",
+                        email = "other@example.com",
+                    ),
+                )
+            val notification =
+                notificationRepository.saveAndFlush(
+                    Notification(
+                        title = "다른 유저 알림",
+                        type = NotificationType.ACTIVITY_CREATED,
+                        link = "/activities/1",
+                        member = otherMember,
+                    ),
+                )
+
+            // when & then
+            mockMvc
+                .delete("/notifications/${notification.id}")
+                .andExpect { status { isNotFound() } }
+                .andExpect { jsonPath("$.code") { value(ErrorCode.NOTIFICATION_NOT_FOUND.status.value()) } }
+                .andExpect { jsonPath("$.message") { value(ErrorCode.NOTIFICATION_NOT_FOUND.message) } }
+
+            val notDeletedNotification = notificationRepository.findById(notification.id)
+            assertThat(notDeletedNotification).isPresent
+            assertThat(notDeletedNotification.get().deletedAt).isNull()
+        }
+    }
+}


### PR DESCRIPTION
## PR 설명
- [✨ feat: 북마크 목록 날짜 응답 추가](https://github.com/picklab/picklab-be/commit/ea3b4aa9d62663cd559e6fad6e81f725ae1c6e16)
- [✨ feat: 알림 개별 삭제 API 추가](https://github.com/picklab/picklab-be/commit/ac8c4019e2c0f6dbed291583de55dff1ae405706)

## 작업 내용
- `GET /v1/bookmarks` 응답을 북마크 목록 전용 DTO로 분리
- 저장 공고 목록 응답에 아래 날짜 필드를 추가
  - `recruitment_start_date`
  - `recruitment_end_date`
  - `bookmarked_at`
- `DELETE /notifications/{notificationId}` 알림 개별 삭제 API를 추가
- 알림 개별 삭제는 기존 전체 삭제 정책과 동일하게 읽음 처리 후 soft delete 처리
